### PR TITLE
Safer Type Conversion Utility functions & 98 MIPS

### DIFF
--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -27,10 +27,6 @@ executable hvms
     hs-source-dirs:   src
     default-language: GHC2024
     c-sources:        src/Runtime.c
-    if os(linux) && arch(x86_64) -- FIXME: Make it detect specificaly AMD arch
-        extra-lib-dirs:  
-        cc-options: -O3 -march=znver3 
-    else 
-        cc-options:  -O3
+    cc-options:  -O3 -march=native -ftree-vectorize
     extra-libraries:  c
     ghc-options:     -Wno-all

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -146,6 +146,13 @@ const Term VOID = 0;
 typedef uint64_t u64;
 typedef _Atomic(u64) a64;
 
+// Using union for type punning (safer in C)
+typedef union {
+    u32 u;
+    i32 i;
+    f32 f;
+} TypeConverter;
+
 // Global heap
 static a64 *BUFF = NULL;
 static a64 RNOD_INI = 0;
@@ -482,12 +489,32 @@ static void interact_opynul(Loc a_loc) {
   move(ret, term_new(NUL, 0, 0));
 }
 
-// Utilities
-u32 u32_to_u32(u32 u) { return u; }
-i32 u32_to_i32(u32 u) { return *(i32 *)&u; }
-f32 u32_to_f32(u32 u) { return *(f32 *)&u; }
-u32 i32_to_u32(i32 i) { return *(u32 *)&i; }
-u32 f32_to_u32(f32 f) { return *(u32 *)&f; }
+// Safer Utilities
+u32 u32_to_u32(u32 u) { return u; }  
+
+i32 u32_to_i32(u32 u) { 
+    TypeConverter converter;
+    converter.u = u;
+    return converter.i;
+}
+
+f32 u32_to_f32(u32 u) {
+    TypeConverter converter;
+    converter.u = u;
+    return converter.f;
+}
+
+u32 i32_to_u32(i32 i) {
+    TypeConverter converter;
+    converter.i = i;
+    return converter.u;
+}
+
+u32 f32_to_u32(f32 f) {
+    TypeConverter converter;
+    converter.f = f;
+    return converter.u;
+}
 
 static void interact_opynum(Loc a_loc, Lab op, u32 y, Tag y_type) {
   u32 x = term_loc(take(port(1, a_loc)));

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -973,26 +973,19 @@ static void interact(Term neg, Term pos) {
   }
 }
 
-// Evaluation
-static inline int normal_step() {
 
-  Loc loc = rbag_pop();
-  if (loc == 0) {
-    // dump_buff();
+static inline int thread_work() {
+    Loc loc = rbag_pop();
+   
+    if(loc == 0) { return 0; }
 
-    return 0;
-  }
+    Term neg = take(loc);
+    Term pos = take(loc + 1);
+    interact(neg, pos);
 
-  Term neg = take(loc + 0);
-  Term pos = take(loc + 1);
-
-  // printf("\n\n%04lX: INTERACT %s ~ %s\n\n", inc_itr(), tag_to_str(neg),
-  // tag_to_str(pos));
-
-  interact(neg, pos);
-
-  return 1;
+    return 1;
 }
+    
 
 void hvm_init() {
   if (BUFF == NULL) {
@@ -1035,12 +1028,10 @@ Term normalize(Term term) {
 
   boot(term_loc(term));
 
-  while (normal_step())
-    ;
-
-  printf("MAX_THREADS: %u\n", MAX_THREADS);
-  /*dump_buff();*/
-
+  while (thread_work());  
+  
+  /*printf("MAX_THREADS: %u\n", MAX_THREADS);*/
+  
   return get(0);
 }
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -994,13 +994,15 @@ static inline int normal_step() {
   return 1;
 }
 
-// FFI exports
 void hvm_init() {
   if (BUFF == NULL) {
-    //    BUFF = malloc((1ULL << 24) * sizeof(a64));
     BUFF = aligned_alloc(64, (1ULL << 26) * sizeof(a64));
+    if (BUFF == NULL) {
+      fprintf(stderr, "Memory allocation failed\n");
+      exit(EXIT_FAILURE);
+    }
   }
-  memset(BUFF, 0, (1ULL << 24) * sizeof(a64));
+  memset(BUFF, 0, (1ULL << 26) * sizeof(a64)); // FIXED ALLOCATION
 
   atomic_store(&RNOD_INI, 0);
   atomic_store(&RNOD_END, 0);


### PR DESCRIPTION
The current approach using type punning through pointer casts (like *(f32 *)&u)) can lead to potential aliasing violations and undefined behavior in some C scenarios, this fixes that using Union types. @Lorenzobattistela 