### PR TITLE
replaced: "CPU time" with "Monotonic time" 99 MIPS avg.

### DIFF
--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -24,6 +24,7 @@ executable hvms
     build-depends:    base ^>=4.21.0.0,
                       containers ^>=0.7,
                       parsec ^>=3.1.17.0,
+                      clock
     hs-source-dirs:   src
     default-language: GHC2024
     c-sources:        src/Runtime.c

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,7 +5,7 @@ import Extract
 import Inject
 import Parse
 import Show
-import System.CPUTime
+import System.Clock
 import System.Environment (getArgs)
 import System.Exit (exitWith, ExitCode(ExitSuccess, ExitFailure))
 import System.IO (readFile, print)
@@ -45,21 +45,21 @@ cliRun filePath showStats = do
 
   -- Only count time for the interactions, not parsing, memory alloc and conversion 
   -- to a human readable format
-  init <- getCPUTime
-  term <- normalize main
-  end <- getCPUTime
+  start <- getTime Monotonic
+  term <- Type.normalize main
+  end <- getTime Monotonic
 
   net <- extractNet term
   putStrLn $ netToString net
 
   when showStats $ do
     -- end <- getCPUTime
-    let time = fromIntegral (end - init) / (10^9) :: Double
+    let timeInMs = fromIntegral (toNanoSecs (diffTimeSpec end start)) / 1000000 :: Double
     itr <- incItr
     len <- rnodEnd
-    let mips = (fromIntegral itr / 1000000.0) / (((time))/ 1000.0)
+    let mips = (fromIntegral itr / 1000000.0) / (((timeInMs))/ 1000.0)
     putStrLn $ "ITRS: " ++ show itr
-    putStrLn $ "TIME: " ++ show time ++ "ms"
+    putStrLn $ "TIME: " ++ show timeInMs ++ "ms"
     putStrLn $ "SIZE: " ++ show len
     putStrLn $ "MIPS: " ++ show mips
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -1,4 +1,4 @@
-// HVM2 Core: single-thread, polarized, LAM/APP & DUP/SUP only
+// HVM3-Strict Core: single-thread, polarized, LAM/APP & DUP/SUP only
 
 #include <stdatomic.h>
 #include <stddef.h>
@@ -145,6 +145,8 @@ const Term VOID = 0;
 // Types
 typedef uint64_t u64;
 typedef _Atomic(u64) a64;
+
+typedef unsigned __int128 u128 __attribute__((aligned(16))); // NOTE gcc/clang specific
 
 // Using union for type punning (safer in C)
 typedef union {


### PR DESCRIPTION
* @Lorenzobattistela 