### PR TITLE
Working, fast, parallel version of HVM3-Strict. ~735MIPS w/10 threads on Mac Mini M4.

### DIFF
--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -11,24 +11,26 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
 common warnings
-    ghc-options: -Wall
+    ghc-options:          -Wall
 
 executable hvms
-    import:           warnings
-    main-is:          Main.hs
-    other-modules:    Type
-                    , Extract
-                    , Inject
-                    , Parse
-                    , Show
-    build-depends:    base ^>=4.21.0.0,
-                      containers ^>=0.7,
-                      parsec ^>=3.1.17.0,
-                      clock
-    hs-source-dirs:   src
-    default-language: GHC2024
-    c-sources:        src/Runtime.c
-    -- cc-options: -march=native -ftree-vectorize
-    cc-options:  -O3
-    extra-libraries:  c
-    ghc-options:     -Wno-all
+    import:               warnings
+    main-is:              Main.hs
+    other-modules:        Type
+                        , Extract
+                        , Inject
+                        , Parse
+                        , Show
+    build-depends:        base ^>=4.21.0.0,
+                          containers ^>=0.7,
+                          parsec ^>=3.1.17.0,
+                          clock
+    hs-source-dirs:       src
+    default-language:     GHC2024
+    c-sources:            src/Runtime.c
+    cc-options:           -O3
+    -- cc-options:           -march=native -ftree-vectorize
+    extra-libraries:      c
+    if os(linux)
+        extra-libraries:  atomic
+    ghc-options:          -Wno-all

--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -28,7 +28,7 @@ executable hvms
     hs-source-dirs:       src
     default-language:     GHC2024
     c-sources:            src/Runtime.c
-    cc-options:           -O2 -Wall -Werror -std=c11
+    cc-options:           -O3 -Wall -Werror -std=c11
     extra-libraries:      c
     if os(linux)
         extra-libraries:  atomic

--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -28,7 +28,7 @@ executable hvms
     hs-source-dirs:       src
     default-language:     GHC2024
     c-sources:            src/Runtime.c
-    cc-options:           -O2 -Wall -Werror
+    cc-options:           -O2 -Wall -Werror -std=c11
     extra-libraries:      c
     if os(linux)
         extra-libraries:  atomic

--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -28,8 +28,7 @@ executable hvms
     hs-source-dirs:       src
     default-language:     GHC2024
     c-sources:            src/Runtime.c
-    cc-options:           -O3
-    -- cc-options:           -march=native -ftree-vectorize
+    cc-options:           -O2 -Wall -Werror
     extra-libraries:      c
     if os(linux)
         extra-libraries:  atomic

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+iters=20
+
+if [ $# -gt 0 ]; then
+  iters="$1"
+fi
+
+cmd="cabal run . -- run examples/bench_parallel_sum_range.hvms -s"
+
+# Initialize variables
+total_mips=0
+min_mips=999999999  # Start with a very high number
+max_mips=0
+
+echo "Running $cmd for $iters iterations..."
+
+# Run the program N times
+for (( i=1; i<=$iters; i++ )); do
+    #echo -n "Run $i/$ITERATIONS: "
+    
+    output=$($cmd 2>/dev/null)
+    
+    mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
+    
+    if [ -z "$mips" ]; then
+        echo "ERROR: Could not find MIPS value in program output"
+        continue
+    fi
+    
+    if [ $mips -lt $min_mips ]; then
+        min_mips=$mips
+    fi
+    
+    if [ $mips -gt $max_mips ]; then
+        max_mips=$mips
+    fi
+    
+    total_mips=$((total_mips + mips))
+done
+
+avg_mips=$(echo "scale=2; $total_mips / $iters" | bc -l)
+
+# Print summary to console
+echo "--------"
+echo "Minimum MIPS: $min_mips"
+echo "Maximum MIPS: $max_mips"
+echo "Average MIPS: $avg_mips"

--- a/bench.sh
+++ b/bench.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-num_iters=20
+num_itrs=20
 
-if [ $# -gt 0 ]; then
-  num_iters="$1"
+if [[ $# > 0 ]]; then
+  num_itrs="$1"
 fi
 
 cleanup() {
     echo "Caught CTRL+C, cleaning up..."
-    pkill -P $$      # Kill all child processes of this script
+    pkill -P $$
     exit 1
 }
 
@@ -16,15 +16,15 @@ trap cleanup SIGINT
 
 cmd="cabal run . -- run examples/bench_parallel_sum_range.hvms -s"
 
-total_mips=0
+tot_mips=0
 min_mips=999999999
 max_mips=0
-first_itrs=0
-outfile=out
+fst_itrs=0
+outfile=out.bench
 
-echo "Running $cmd for $num_iters iterations..."
+echo "Running $cmd for $num_itrs iterations..."
 
-for (( i=1; i<=$num_iters; i++ )); do
+for (( i=1; i<=$num_itrs; i++ )); do
     output=$($cmd 2>$outfile)
     
     mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
@@ -33,18 +33,18 @@ for (( i=1; i<=$num_iters; i++ )); do
     
     [[ -z "$itrs" ]] && err=1 || err=0
 
-    if (( !err )) && [[ $first_itrs == 0 ]]; then
-        first_itrs="$itrs"
-    elif (( err )) || [[ $first_itrs != $itrs ]]; then
+    if (( !err )) && [[ $fst_itrs == 0 ]]; then
+        fst_itrs="$itrs"
+    elif (( err )) || [[ $fst_itrs != $itrs ]]; then
         if (( err )); then
             echo "ERROR @ $i: missing ITRS"
         else
-            echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+            echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $fst_itrs"
         fi
         echo "Output:"
         echo "$output"
         echo "------"
-        echo "tail out:"
+        echo "tail $outfile:"
         tail "$outfile"
         exit 1
     fi
@@ -57,12 +57,12 @@ for (( i=1; i<=$num_iters; i++ )); do
         max_mips="$mips"
     fi
     
-    total_mips=$((total_mips + mips))
+    tot_mips=$((tot_mips + mips))
 done
 
-avg_mips=$(echo "scale=2; $total_mips / $num_iters" | bc -l)
+avg_mips=$(echo "scale=2; $tot_mips / $num_itrs" | bc -l)
 
 echo "--------"
-echo "Minimum MIPS: $min_mips"
-echo "Maximum MIPS: $max_mips"
-echo "Average MIPS: $avg_mips"
+echo "Min MIPS: $min_mips"
+echo "Max MIPS: $max_mips"
+echo "Avg MIPS: $avg_mips"

--- a/bench.sh
+++ b/bench.sh
@@ -34,10 +34,10 @@ for (( i=1; i<=$num_iters; i++ )); do
     if [ "$first_itrs" -eq 0 ]; then
         first_itrs="$itrs"
     elif [ "$first_itrs" -ne "$itrs" ]; then
-        echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
-        #echo "Output:"
-        #echo "$output"
-        #exit 1
+        echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+        echo "Output:"
+        echo "$output"
+        exit 1
     fi
 
     if [ "$first_size" -eq 0 ]; then

--- a/bench.sh
+++ b/bench.sh
@@ -25,16 +25,13 @@ outfile=out
 echo "Running $cmd for $num_iters iterations..."
 
 for (( i=1; i<=$num_iters; i++ )); do
-    echo 1
     output=$($cmd 2>$outfile)
-    echo 2
     
     mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
     itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
     size=$(echo "$output" | grep "SIZE:" | awk '{print $2}')
     
     [[ -z "$itrs" ]] && err=1 || err=0
-    echo "err=$err, itrs=$itrs"
 
     if (( !err )) && [[ $first_itrs == 0 ]]; then
         first_itrs="$itrs"
@@ -50,8 +47,6 @@ for (( i=1; i<=$num_iters; i++ )); do
         echo "tail out:"
         tail "$outfile"
         exit 1
-    else
-        echo what
     fi
 
     if [[ $mips < $min_mips ]]; then

--- a/bench.sh
+++ b/bench.sh
@@ -13,11 +13,12 @@ min_mips=999999999
 max_mips=0
 first_itrs=0
 first_size=0
+outfile=out
 
 echo "Running $cmd for $num_iters iterations..."
 
 for (( i=1; i<=$num_iters; i++ )); do
-    output=$($cmd 2>/dev/null)
+    output=$($cmd 2>$outfile)
     
     mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
     itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
@@ -32,16 +33,20 @@ for (( i=1; i<=$num_iters; i++ )); do
         first_itrs="$itrs"
     elif [ "$first_itrs" -ne "$itrs" ]; then
         echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+        echo "Output:"
+        echo "$output"
+        exit 1
     fi
 
     if [ "$first_size" -eq 0 ]; then
         first_size="$size"
     elif [ "$first_size" -ne "$size" ]; then
         echo "ERROR: SIZE: $size mismatch with first SIZE: $first_size"
+        exit 1
     fi
 
     if [ "$mips" -lt "$min_mips" ]; then
-        min_mips=$mips
+        min_mips="$mips"
     fi
     
     if [ "$mips" -gt "$max_mips" ]; then

--- a/bench.sh
+++ b/bench.sh
@@ -35,8 +35,8 @@ for (( i=1; i<=$num_iters; i++ )); do
         first_itrs="$itrs"
     elif [ "$first_itrs" -ne "$itrs" ]; then
         echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
-        #echo "Output:"
-        #echo "$output"
+        echo "Output:"
+        echo "$output"
         #exit 1
     fi
 

--- a/bench.sh
+++ b/bench.sh
@@ -6,28 +6,40 @@ if [ $# -gt 0 ]; then
   num_iters="$1"
 fi
 
+cleanup() {
+    echo "Caught CTRL+C, cleaning up..."
+    pkill -P $$      # Kill all child processes of this script
+    exit 1
+}
+
+trap cleanup SIGINT
+
 cmd="cabal run . -- run examples/bench_parallel_sum_range.hvms -s"
 
 total_mips=0
 min_mips=999999999
 max_mips=0
 first_itrs=0
-first_size=0
 outfile=out
 
 echo "Running $cmd for $num_iters iterations..."
 
 for (( i=1; i<=$num_iters; i++ )); do
+    echo 1
     output=$($cmd 2>$outfile)
+    echo 2
     
     mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
     itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
     size=$(echo "$output" | grep "SIZE:" | awk '{print $2}')
     
-    if [ "$first_itrs" -eq 0 ]; then
+    [[ -z "$itrs" ]] && err=1 || err=0
+    echo "err=$err, itrs=$itrs"
+
+    if (( !err )) && [[ $first_itrs == 0 ]]; then
         first_itrs="$itrs"
-    elif [ -z "$itrs" ] || [ "$first_itrs" -ne "$itrs" ]; then
-        if [ -z "$itrs" ]; then
+    elif (( err )) || [[ $first_itrs != $itrs ]]; then
+        if (( err )); then
             echo "ERROR @ $i: missing ITRS"
         else
             echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $first_itrs"
@@ -38,20 +50,15 @@ for (( i=1; i<=$num_iters; i++ )); do
         echo "tail out:"
         tail "$outfile"
         exit 1
+    else
+        echo what
     fi
 
-    if [ "$first_size" -eq 0 ]; then
-        first_size="$size"
-    elif [ "$first_size" -ne "$size" ]; then
-        echo "ERROR: SIZE: $size mismatch with first SIZE: $first_size"
-        #exit 1
-    fi
-
-    if [ "$mips" -lt "$min_mips" ]; then
+    if [[ $mips < $min_mips ]]; then
         min_mips="$mips"
     fi
     
-    if [ "$mips" -gt "$max_mips" ]; then
+    if [[ $mips > $max_mips ]]; then
         max_mips="$mips"
     fi
     

--- a/bench.sh
+++ b/bench.sh
@@ -24,19 +24,19 @@ for (( i=1; i<=$num_iters; i++ )); do
     itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
     size=$(echo "$output" | grep "SIZE:" | awk '{print $2}')
     
-    if [ -z "$mips" ] || [ -z "$itrs" ] || [ -z "$size" ]; then
-        echo "ERROR: Could not find MIPS, ITRS, or SIZE in program output"
-        echo "Output:"
-        echo "$output"
-        continue
-    fi
-    
     if [ "$first_itrs" -eq 0 ]; then
         first_itrs="$itrs"
-    elif [ "$first_itrs" -ne "$itrs" ]; then
-        echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+    elif [ -z "$itrs" ] || [ "$first_itrs" -ne "$itrs" ]; then
+        if [ -z "$itrs" ]; then
+            echo "ERROR @ $i: missing ITRS"
+        else
+            echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+        fi
         echo "Output:"
         echo "$output"
+        echo "------"
+        echo "tail out:"
+        tail "$outfile"
         exit 1
     fi
 

--- a/bench.sh
+++ b/bench.sh
@@ -1,47 +1,58 @@
 #!/bin/bash
 
-iters=20
+num_iters=20
 
 if [ $# -gt 0 ]; then
-  iters="$1"
+  num_iters="$1"
 fi
 
 cmd="cabal run . -- run examples/bench_parallel_sum_range.hvms -s"
 
-# Initialize variables
 total_mips=0
-min_mips=999999999  # Start with a very high number
+min_mips=999999999
 max_mips=0
+first_itrs=0
+first_size=0
 
-echo "Running $cmd for $iters iterations..."
+echo "Running $cmd for $num_iters iterations..."
 
-# Run the program N times
-for (( i=1; i<=$iters; i++ )); do
-    #echo -n "Run $i/$ITERATIONS: "
-    
+for (( i=1; i<=$num_iters; i++ )); do
     output=$($cmd 2>/dev/null)
     
     mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
+    itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
+    size=$(echo "$output" | grep "SIZE:" | awk '{print $2}')
     
-    if [ -z "$mips" ]; then
-        echo "ERROR: Could not find MIPS value in program output"
+    if [ -z "$mips" ] || [ -z "$itrs" ] || [ -z "$size" ]; then
+        echo "ERROR: Could not find MIPS, ITRS, or SIZE in program output"
         continue
     fi
     
-    if [ $mips -lt $min_mips ]; then
+    if [ "$first_itrs" -eq 0 ]; then
+        first_itrs="$itrs"
+    elif [ "$first_itrs" -ne "$itrs" ]; then
+        echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
+    fi
+
+    if [ "$first_size" -eq 0 ]; then
+        first_size="$size"
+    elif [ "$first_size" -ne "$size" ]; then
+        echo "ERROR: SIZE: $size mismatch with first SIZE: $first_size"
+    fi
+
+    if [ "$mips" -lt "$min_mips" ]; then
         min_mips=$mips
     fi
     
-    if [ $mips -gt $max_mips ]; then
-        max_mips=$mips
+    if [ "$mips" -gt "$max_mips" ]; then
+        max_mips="$mips"
     fi
     
     total_mips=$((total_mips + mips))
 done
 
-avg_mips=$(echo "scale=2; $total_mips / $iters" | bc -l)
+avg_mips=$(echo "scale=2; $total_mips / $num_iters" | bc -l)
 
-# Print summary to console
 echo "--------"
 echo "Minimum MIPS: $min_mips"
 echo "Maximum MIPS: $max_mips"

--- a/bench.sh
+++ b/bench.sh
@@ -37,7 +37,7 @@ for (( i=1; i<=$num_iters; i++ )); do
         echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
         echo "Output:"
         echo "$output"
-        #exit 1
+        exit 1
     fi
 
     if [ "$first_size" -eq 0 ]; then

--- a/bench.sh
+++ b/bench.sh
@@ -26,6 +26,8 @@ for (( i=1; i<=$num_iters; i++ )); do
     
     if [ -z "$mips" ] || [ -z "$itrs" ] || [ -z "$size" ]; then
         echo "ERROR: Could not find MIPS, ITRS, or SIZE in program output"
+        echo "Output:"
+        echo "$output"
         continue
     fi
     
@@ -33,16 +35,16 @@ for (( i=1; i<=$num_iters; i++ )); do
         first_itrs="$itrs"
     elif [ "$first_itrs" -ne "$itrs" ]; then
         echo "ERROR: ITRS: $itrs mismatch with first ITRS: $first_itrs"
-        echo "Output:"
-        echo "$output"
-        exit 1
+        #echo "Output:"
+        #echo "$output"
+        #exit 1
     fi
 
     if [ "$first_size" -eq 0 ]; then
         first_size="$size"
     elif [ "$first_size" -ne "$size" ]; then
         echo "ERROR: SIZE: $size mismatch with first SIZE: $first_size"
-        exit 1
+        #exit 1
     fi
 
     if [ "$mips" -lt "$min_mips" ]; then

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 2
+@height = 20
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 19
+@height = 2
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 20
+@height = 15
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 15
+@height = 20
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 8
+@height = 20
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 20
+@height = 8
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -7,9 +7,7 @@ import Type
 -- ------------
 
 extractPCore :: Term -> IO PCore
-extractPCore term = do
-  putStrLn $ "extractPCore: " ++ show (termTag term)
-  case termTag term of
+extractPCore term = case termTag term of
     VAR -> do
       got <- get (termLoc term)
       extractVar (termLoc term) got
@@ -40,9 +38,7 @@ extractPCore term = do
 -- The optional location is the location of the term
 -- being extracted in the buffer.
 extractNCore :: Loc -> Term -> IO NCore
-extractNCore loc term = do
-  putStrLn $ "extractNCore: " ++ show (termTag term)
-  case termTag term of
+extractNCore loc term = case termTag term of
     ERA -> return NEra
     SUB -> return $ NSub ("v" ++ show loc)
     APP -> do
@@ -112,7 +108,6 @@ extractBag (loc:locs) = do
 
 extractNet :: Term -> IO Net
 extractNet root = do
-  putStrLn $ "extractNet: " ++ show (termLoc root)
   root' <- extractPCore root
   ini   <- rbagIni
   end   <- rbagEnd

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -32,6 +32,7 @@ extractPCore term = case termTag term of
   U32 -> return $ PU32 (termLoc term)
   I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
   F32 -> return $ PF32 (word32ToFloat $ termLoc term)
+  tag -> error $ "extractPCore: unhandled case: " ++ show tag
 
 -- Convert a term in memory to a NCore.
 -- The optional location is the location of the term

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -32,7 +32,6 @@ extractPCore term = case termTag term of
   U32 -> return $ PU32 (termLoc term)
   I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
   F32 -> return $ PF32 (word32ToFloat $ termLoc term)
-  tag -> error $ "extractPCore: unhandled case: " ++ show tag
 
 -- Convert a term in memory to a NCore.
 -- The optional location is the location of the term
@@ -70,7 +69,6 @@ extractNCore loc term = case termTag term of
     arg' <- extractPCore arg
     ret' <- extractNCore (loc + 1) ret
     return $ NOp2 op arg' ret'
-  tag -> error $ "extractNCore: unhandled case: " ++ show tag
 
 extractVar :: Loc -> Term -> IO PCore
 extractVar loc term = case termTag term of
@@ -101,7 +99,6 @@ extractDex loc = do
 extractBag :: [Loc] -> IO Bag
 extractBag [] = return []
 extractBag (loc:locs) = do
-  putStrLn $ "extractBag "
   dex  <- extractDex loc
   dexs <- extractBag locs
   return (dex : dexs)

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -8,69 +8,69 @@ import Type
 
 extractPCore :: Term -> IO PCore
 extractPCore term = case termTag term of
-    VAR -> do
-      got <- get (termLoc term)
-      extractVar (termLoc term) got
-    REF -> do
-      name <- defName (termLoc term)
-      return $ PRef name
-    NUL -> return PNul
-    LAM -> do
-      let loc = termLoc term
-      var <- get (loc + 0)
-      bod <- get (loc + 1)
-      var' <- extractNCore (loc + 0) var
-      bod' <- extractPCore bod
-      return $ PLam var' bod'
-    SUP -> do
-      let loc = termLoc term
-      tm1 <- get (loc + 0)
-      tm2 <- get (loc + 1)
-      tm1' <- extractPCore tm1
-      tm2' <- extractPCore tm2
-      return $ PSup tm1' tm2'
-    U32 -> return $ PU32 (termLoc term)
-    I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
-    F32 -> return $ PF32 (word32ToFloat $ termLoc term)
-    tag -> error $ "extractPCore: unhandled case: " ++ show tag
+  VAR -> do
+    got <- get (termLoc term)
+    extractVar (termLoc term) got
+  REF -> do
+    name <- defName (termLoc term)
+    return $ PRef name
+  NUL -> return PNul
+  LAM -> do
+    let loc = termLoc term
+    var <- get (loc + 0)
+    bod <- get (loc + 1)
+    var' <- extractNCore (loc + 0) var
+    bod' <- extractPCore bod
+    return $ PLam var' bod'
+  SUP -> do
+    let loc = termLoc term
+    tm1 <- get (loc + 0)
+    tm2 <- get (loc + 1)
+    tm1' <- extractPCore tm1
+    tm2' <- extractPCore tm2
+    return $ PSup tm1' tm2'
+  U32 -> return $ PU32 (termLoc term)
+  I32 -> return $ PI32 (word32ToInt32 $ termLoc term)
+  F32 -> return $ PF32 (word32ToFloat $ termLoc term)
+  tag -> error $ "extractPCore: unhandled case: " ++ show tag
 
 -- Convert a term in memory to a NCore.
 -- The optional location is the location of the term
 -- being extracted in the buffer.
 extractNCore :: Loc -> Term -> IO NCore
 extractNCore loc term = case termTag term of
-    ERA -> return NEra
-    SUB -> return $ NSub ("v" ++ show loc)
-    APP -> do
-      let loc = termLoc term
-      arg <- get (loc + 0)
-      ret <- get (loc + 1)
-      arg' <- extractPCore arg
-      ret' <- extractNCore (loc + 1) ret
-      return $ NApp arg' ret'
-    DUP -> do
-      let loc = termLoc term
-      dp1 <- get (loc + 0)
-      dp2 <- get (loc + 1)
-      dp1' <- extractNCore (loc + 0) dp1
-      dp2' <- extractNCore (loc + 1) dp2
-      return $ NDup dp1' dp2'
-    MAT -> do
-      let num = termLab term
-      let loc = termLoc term
-      let extractArm i = get (loc + i) >>= extractPCore
-      ret  <- get (loc + 0) >>= extractNCore (loc + 0)
-      arms <- mapM extractArm [1..num]
-      return $ NMat ret arms
-    x | elem x [OPX, OPY] -> do
-      let op  = termOper term
-      let loc = termLoc term
-      arg <- get (loc + 0)
-      ret <- get (loc + 1)
-      arg' <- extractPCore arg
-      ret' <- extractNCore (loc + 1) ret
-      return $ NOp2 op arg' ret'
-    tag -> error $ "extractNCore: unhandled case: " ++ show tag
+  ERA -> return NEra
+  SUB -> return $ NSub ("v" ++ show loc)
+  APP -> do
+    let loc = termLoc term
+    arg <- get (loc + 0)
+    ret <- get (loc + 1)
+    arg' <- extractPCore arg
+    ret' <- extractNCore (loc + 1) ret
+    return $ NApp arg' ret'
+  DUP -> do
+    let loc = termLoc term
+    dp1 <- get (loc + 0)
+    dp2 <- get (loc + 1)
+    dp1' <- extractNCore (loc + 0) dp1
+    dp2' <- extractNCore (loc + 1) dp2
+    return $ NDup dp1' dp2'
+  MAT -> do
+    let num = termLab term
+    let loc = termLoc term
+    let extractArm i = get (loc + i) >>= extractPCore
+    ret  <- get (loc + 0) >>= extractNCore (loc + 0)
+    arms <- mapM extractArm [1..num]
+    return $ NMat ret arms
+  x | elem x [OPX, OPY] -> do
+    let op  = termOper term
+    let loc = termLoc term
+    arg <- get (loc + 0)
+    ret <- get (loc + 1)
+    arg' <- extractPCore arg
+    ret' <- extractNCore (loc + 1) ret
+    return $ NOp2 op arg' ret'
+  tag -> error $ "extractNCore: unhandled case: " ++ show tag
 
 extractVar :: Loc -> Term -> IO PCore
 extractVar loc term = case termTag term of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -58,9 +58,9 @@ cliRun filePath showStats = do
     len <- rnodEnd
     let mips = (fromIntegral itr / 1000000.0) / (((timeInMs))/ 1000.0)
     putStrLn $ "ITRS: " ++ show itr
-    putStrLn $ "INTERACTION TIME: " ++ show timeInMs ++ "ms"
+    putStrLn $ "TIME: " ++ show (truncate timeInMs) ++ "ms"
     putStrLn $ "SIZE: " ++ show len
-    putStrLn $ "MIPS: " ++ show mips
+    putStrLn $ "MIPS: " ++ show (truncate mips)
 
   hvmFree
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -50,11 +50,9 @@ cliRun filePath showStats = do
   end <- getTime Monotonic
     
   net <- extractNet term
-
   putStrLn $ netToString net
 
   when showStats $ do
-    -- end <- getCPUTime
     let timeInMs = fromIntegral (toNanoSecs (diffTimeSpec end start)) / 1000000 :: Double
     itr <- incItr
     len <- rnodEnd

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -50,7 +50,10 @@ cliRun filePath showStats = do
   end <- getTime Monotonic
     
   net <- extractNet term
-  putStrLn $ netToString net
+  let str = netToString net
+  putStrLn $ str
+  when (not (null str) && head str == 'v') $ do
+    callFailureHandler
 
   when showStats $ do
     let timeInMs = fromIntegral (toNanoSecs (diffTimeSpec end start)) / 1000000 :: Double

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -111,15 +111,16 @@ enum : u64 {
   CLINE_U64 = CLINE_BYTES / sizeof(u64),
 
   // Threads per CPU
-  TPC = 8,
+  TPC = 10,
 
   // Various redex bag starting indices within the heap to choose from.
   // The remaining percentage is used for node storage.
 
-  // Cache-aligned and named for the percentage of heap used.
+  // Named for the percentage of heap used.
   RBAG_25_PCT = (HEAP_SIZE / 4),
   RBAG_50_PCT = (HEAP_SIZE / 2),
   RBAG_75_PCT = (HEAP_SIZE - (HEAP_SIZE / 4)),
+  // TODO: something like: RBAG_1024_DEX, for 1024 redex per thread
 
   ////////////////////////////////////
   // Choose a RBAG size here
@@ -129,11 +130,11 @@ enum : u64 {
 
 enum : u32 {
   // Final calculated RBAG index
-  RBAG = (HEAP_SIZE - RBAG_SIZE) / sizeof(u64),
+  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(u64)) & ~7U, // CLINE_U64 - 1
 
   // Calculate RBAG_LEN and NODE_LEN: number of u64 elements *per thread*
   // TODO: MUST be 16-byte aligned. 64-byte alignment might be preferable.
-  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~15U,
+  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~7U, // CLINE_U64 - 1
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64))
 };
 
@@ -271,6 +272,7 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
+//#define DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
 
@@ -290,12 +292,14 @@ static bool good_loc(Loc loc) { return true; }
 Term swap(Loc loc, Term term) {
   Term res = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 
+#ifdef DEBUG
   if (mop_debug && good_loc(loc)) {
     char buf1[TERMSTR_BUFSIZ];
     char buf2[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d swap %u %s with %s\n", thread_id, loc,
         term_str(buf1, res), term_str(buf2, term));
   }
+#endif
 
   return res;
 }
@@ -303,10 +307,12 @@ Term swap(Loc loc, Term term) {
 Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
 
+#ifdef DEBUG
   if (mop_debug && good_loc(loc)) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d get %u %s\n", thread_id, loc, term_str(buf, term));
   }
+#endif
 
   return term;
 }
@@ -314,10 +320,12 @@ Term get(Loc loc) {
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
 
+#ifdef DEBUG
   if (mop_debug && good_loc(loc)) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d take %u %s\n", thread_id, loc, term_str(buf, term));
   }
+#endif
 
   return term;
 }
@@ -325,20 +333,24 @@ Term take(Loc loc) {
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 
+#ifdef DEBUG
   if (mop_debug && good_loc(loc)) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d set %u %s\n", thread_id, loc, term_str(buf, term));
   }
+#endif
 }
 
 static Pair take_pair(Loc loc) {
   Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], 0ULL, __ATOMIC_RELAXED);
 
+#ifdef DEBUG
   if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d take.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
     fprintf(stderr, "%d take.pos %u %s\n", thread_id, loc + 1, term_str(buf, pair_pos(pair)));
   }
+#endif
 
   return pair;
 }
@@ -346,11 +358,13 @@ static Pair take_pair(Loc loc) {
 static void set_pair(Loc loc, Pair pair) {
   __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
 
+#ifdef DEBUG
   if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d set.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
     fprintf(stderr, "%d set.pos %u %s\n", thread_id, loc + 1, term_str(buf, pair_pos(pair)));
   }
+#endif
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -359,9 +373,11 @@ static Loc port(u64 n, Loc loc) { return n + loc - 1; }
 // ---------
 
 static Loc node_alloc(TM *tm, u32 num) {
+#ifdef DEBUG
   if (mop_debug) {
     fprintf(stderr, "%u alloc %u nodes at %u\n", tm->tid, num, tm->nput);
   }
+#endif
 
   if (tm->nput + num >= NODE_LEN) {
     fprintf(stderr, "node space exhausted\n");
@@ -384,9 +400,11 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
   Loc loc = RBAG + tm->tid * RBAG_LEN + tm->rput;
 
+#ifdef DEBUG
   if (0 && mop_debug) {
     fprintf(stderr, "%u calling set_pair @ %u, rput %u\n", tm->tid, loc, tm->rput);
   }
+#endif
 
   set_pair(loc, pair_new(neg, pos));
   tm->rput += 2;
@@ -414,7 +432,7 @@ void hvm_init() {
 
   alloc_static_tms();
 
-  #if 0
+  #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
   fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
   fprintf(stderr, "RBAG      = %u\n", RBAG);
@@ -527,10 +545,12 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   // offset calculation must occur before node_alloc() call
   Loc offset = (tm->tid * NODE_LEN) + tm->nput - 1;
 
+#ifdef DEBUG
   if (mop_debug) {
     fprintf(stderr, "%u expand_ref %u nodes %u rbag %u offset %u\n", tm->tid,
         def_idx, nodes_len, rbag_len, offset);
   }
+#endif
 
   node_alloc(tm, nodes_len - 1);
 
@@ -542,10 +562,12 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     Term term = term_offset_loc(nodes[i], offset);
     BUFF[loc] = term;
 
+#ifdef DEBUG
     if (mop_debug) {
       char buf[TERMSTR_BUFSIZ];
       fprintf(stderr, "%u node %u %s\n", tm->tid, loc, term_str(buf, term));
     }
+#endif
   }
 
   for (u32 i = 0; i < rbag_len; i += 2) {
@@ -1338,7 +1360,7 @@ static void* thread_func(void* arg) {
   atomic_fetch_add(&net.nods, tm->nput);
   atomic_fetch_add(&net.itrs, tm->itrs);
 
-  if (1) {
+  if (0) {
     fprintf(stderr, "t%u: %" PRIu64 " itrs, steals: %u good %u bad\n",
             tm->tid, tm->itrs, tm->sgud, tm->sbad);
   }
@@ -1383,7 +1405,8 @@ Term normalize(Term term) {
     TM *tm = tms[0];
     while (sequential_step(tm))
       ;
-    atomic_fetch_add(&net.nods, tm->nput);
+    net.nods = tm->nput;
+    net.itrs = tm->itrs;
   } else {
     parallel_normalize();
   }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -31,6 +31,40 @@ int thread_join(pthread_t thread, void **retval) {
   return pthread_join(thread, retval);
 }
 
+#ifdef __APPLE__
+
+extern void store_barrier(void);
+__asm__(
+    ".global _store_barrier\n"
+    ".global store_barrier\n"
+    "_store_barrier:\n"
+    "store_barrier:\n"
+    "   dmb ishst\n"
+    "   ret\n"
+);
+
+extern void load_barrier(void);  
+__asm__(
+    ".global _load_barrier\n"
+    ".global load_barrier\n"
+    "_load_barrier:\n"
+    "load_barrier:\n"
+    "   dmb ishld\n"
+    "   ret\n"
+);
+
+#if 0
+void store_barrier(void) {
+    __asm__ __volatile__("dmb ishst" ::: "memory");
+}
+
+void load_barrier(void) {
+    __asm__ __volatile__("dmb ishld" ::: "memory");
+}
+#endif
+
+#endif // __APPLE__
+
 // Constants
 #define VAR 0x01
 #define SUB 0x02
@@ -135,7 +169,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 8
+  BBAG_LEN = 96
 };
 
 typedef struct Net {
@@ -231,7 +265,7 @@ static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
-#define MEMLOG // comment out to disable
+//#define MEMLOG // comment out to disable
 //#define LOCLOG
 
 #if defined(MEMLOG) && defined(LOCLOG)
@@ -248,12 +282,12 @@ enum : u32 {
 };
 
 //static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
-#define MLOG_PAIR(mop, loc, pair)       mlog((u32)thread_id, mop, loc, pair_neg(pair), pair_pos(pair), 0)
-#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
+#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0, false)
+#define MLOG_PAIR(mop, loc, pair, lvl)  mlog((u32)thread_id, mop, loc, pair_neg(pair), pair_pos(pair), lvl, true)
+#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl, false)
 #else
 #define MLOG(mop, loc, t1, t2)
-#define MLOG_PAIR(mop, loc, pair)
+#define MLOG_PAIR(mop, loc, pair, lvl)
 #define MLOG_LVL(mop, loc, lvl, t1, t2)
 #endif
 
@@ -327,7 +361,7 @@ static void mlog_free() {
   }
 }
 
-// i1_tag: 4, i2_tag: 4, lvl: 5, op:2, t1_tag: 4, t2_tag: 4, tid: 4, sid: 4
+// i1_tag: 4, i2_tag: 4, lvl: 5, op: 2, t1_tag: 4, t2_tag: 4, tid: 4, sid: 4
 
 static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
                       u32 i1_tag, u32 i2_tag, u32 t1_tag, u32 t2_tag) {
@@ -427,7 +461,9 @@ static void mlog_dump(const char* fn) {
 }
 
 #ifdef __APPLE__
-// Use explicit file-scope assembly to define the function
+
+// Use explicit file-scope assembly to prevent compiler from optimizing out
+
 extern uint64_t read_cntvct(void);
 __asm__(
     ".global _read_cntvct\n"
@@ -440,7 +476,7 @@ __asm__(
 );
 #endif
 
-static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
+static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl, bool force_t2) {
   static bool at_end = false;
 
   TM *tm = tms[tid];
@@ -595,8 +631,12 @@ static const char* term_str(char* buf, Term term) {
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
-  log_term_loc(MOP_STOR, term, loc);
-  log_term_loc(MOP_LOAD, got, loc);
+  return got;
+}
+
+Term swap_seq_cst(Loc loc, Term term, u32 lvl) {
+  Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_acquire);
+  MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
   return got;
 }
 
@@ -607,21 +647,27 @@ Term swap(Loc loc, Term term) {
 Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
   MLOG(MOP_LOAD, loc, term, 0);
-  log_term_loc(MOP_LOAD, term, loc);
+  //log_term_loc(MOP_LOAD, term, loc);
   return term;
 }
 
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
-  log_term_loc(MOP_LOAD, term, loc);
+  //log_term_loc(MOP_LOAD, term, loc);
   return term;
+}
+
+void set_release(Loc loc, Term term) {
+  atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_release);
+  MLOG(MOP_STOR, loc, term, 0);
+  //log_term_loc(MOP_STOR, term, loc);
 }
 
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG(MOP_STOR, loc, term, 0);
-  log_term_loc(MOP_STOR, term, loc);
+  //log_term_loc(MOP_STOR, term, loc);
 }
 
 static Pair take_pair(Loc loc, bool bty) {
@@ -637,9 +683,9 @@ static Pair take_pair(Loc loc, bool bty) {
   tm->i2_tag = term_tag(pos);
   tm->itid = bty ? tm->btid : tm->tid;
 
-  MLOG(MOP_LOAD, loc, neg, pos);
+  MLOG_PAIR(MOP_LOAD, loc, pair, 0);
 
-#ifdef LOCLOC
+#ifdef LOCLOG
   log_pair_loc(MOP_LOAD, pair, loc);
 #endif
 #endif
@@ -656,14 +702,16 @@ static Pair take_pair(Loc loc, bool bty) {
   return pair;
 }
 
+/* Careful of 2 MLOG calls if you re-enable this
 static void atomic_set_pair(Loc loc, Pair pair) {
   __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
-  MLOG_PAIR(MOP_STOR, loc, pair);
+  MLOG_PAIR(MOP_STOR, loc, pair, 0);
 }
+*/
 
 static void set_pair(Loc loc, Pair pair) {
   *((Pair*)&BUFF[loc]) = pair;
-  MLOG_PAIR(MOP_STOR, loc, pair);
+  MLOG_PAIR(MOP_STOR, loc, pair, 0);
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -734,7 +782,7 @@ static Loc rbag_push(TM *tm, Term neg, Term pos) {
   Pair pair = pair_new(neg, pos);
   set_pair(loc, pair);
 
-  log_pair_loc(MOP_STOR, pair, loc);
+  //log_pair_loc(MOP_STOR, pair, loc);
 
   if (bty) {
     tm->bput += 2;
@@ -920,6 +968,11 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   Term root = term_offset_loc(nodes[0], offset);
 
+  //#define ELOG
+#ifdef ELOG
+  fprintf(stderr, "%s (%u)\n", def->name, def_idx);
+#endif
+
   u32 n = 1;
   for (; n + 1 < nodes_len; n += 2) {
     // 128-bit load & store
@@ -927,25 +980,50 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     Term neg = term_offset_loc(pair_neg(orig), offset);
     Term pos = term_offset_loc(pair_pos(orig), offset);
     Loc loc = offset + n;
+
     // What if we add these without atomics, then release on first
     // rbag_push, and acquire on take_pair?
-    //*(Pair*)&BUFF[loc] = pair_new(neg, pos);
-    atomic_set_pair(loc, pair_new(neg, pos));
-    MLOG_LVL(MOP_STOR, loc, def_idx, neg, pos);
-    log_term_loc(MOP_STOR, neg, loc);
-    log_term_loc(MOP_STOR, pos, loc+1);
+    Pair pair = pair_new(neg, pos);
+#if 0
+    if (n+2 == nodes_len) {
+      __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELEASE);
+    } else
+#endif
+    {
+      *(Pair*)&BUFF[loc] = pair_new(neg, pos);
+    }
+    MLOG_PAIR(MOP_STOR, loc, pair, def_idx);
+    //log_term_loc(MOP_STOR, neg, loc);
+    //log_term_loc(MOP_STOR, pos, loc+1);
   }
   if (n < nodes_len) {
     Term term = term_offset_loc(nodes[n], offset);
+#if 0
+    set_release(offset + n, term);
+#else
     BUFF[offset + n] = term;
+#endif
     MLOG_LVL(MOP_STOR, offset+n, def_idx, term, 0);
   }
+
+  //atomic_thread_fence(memory_order_release);
+  //store_barrier();
 
   for (u32 i = 0; i < rbag_len; i += 2) {
     // 128-bit load
     Pair pair = *(Pair*)&rbag[i];
     Loc loc = rbag_push(tm, term_offset_loc(pair_neg(pair), offset),
                         term_offset_loc(pair_pos(pair), offset));
+
+#ifdef ELOG
+    Term pos = pair_pos(pair);
+    Term neg = pair_neg(pair);
+    if ((term_tag(neg) == APP) && (term_tag(pos) == REF)) {
+      u32 ref_idx = term_loc(pos);
+      const Def* ref_def = &BOOK.defs[ref_idx];
+      fprintf(stderr, "  %s (%u)\n", ref_def->name, ref_idx);
+    }
+#endif
   }
 
   return root;
@@ -963,27 +1041,35 @@ static void boot(Loc def_idx) {
 
 // Atomic Linker
 static inline void move(TM *tm, Loc neg_loc, Term pos);
-static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl, Term exp_neg);
+static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl);
 
 static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
     Loc loc = term_loc(pos);
-    Term far = swap_lvl(loc, neg, lvl);
+    Term far;
+    // Before swapping in a VAR, ensure that whatever is at the VAR's loc
+    // is actually populated with something. If it's not, cheese out and
+    // force seq_cst memory.
+    // There might be a faster/better (and probably more complicated) way,
+    // but this is guaranteed to work and such cases are hopefully uncommon.
+#if 0
+    if (get(loc) == 0) {
+      far = swap_seq_cst(loc, neg, lvl);
+    } else
+#endif
+    {
+      far = swap_lvl(loc, neg, lvl);
+    }
     if (term_tag(far) != SUB) {
-      move_lvl(tm, term_loc(pos), far, lvl + 1, neg);
+      move_lvl(tm, term_loc(pos), far, lvl + 1);
     }
   } else {
     rbag_push(tm, neg, pos);
   }
 }
 
-static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl, Term exp_neg) {
+static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl) {
   Term neg = swap_lvl(neg_loc, pos, lvl);
-#if 0
-  if ((lvl > 0) && (exp_neg != neg)) {
-    fprintf(stderr, "OOF\n");
-  }
-#endif
   if (term_tag(neg) != SUB) {
     // No need to take() since we already swapped
     link_lvl(tm, neg, pos, lvl + 1);
@@ -995,11 +1081,13 @@ static inline void link_terms(TM *tm, Term neg, Term pos) {
 }
 
 static inline void move(TM *tm, Loc neg_loc, Term pos) {
-  move_lvl(tm, neg_loc, pos, 0, 0);
+  move_lvl(tm, neg_loc, pos, 0);
 }
 
 // Interactions
-static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
+static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
+  return true;
+
   Term arg = take(port(1, a_loc));
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
@@ -1013,6 +1101,8 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   move(tm, ret, bod);
 
   tm->buse = buse;
+
+  return true;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1474,6 +1564,8 @@ static void interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
+  fprintf(stderr, "%s%s\n", tag_to_str(neg_tag), tag_to_str(pos_tag));
+
   bool processed = true;
 
   switch (neg_tag) {
@@ -1787,6 +1879,8 @@ Term normalize(Term term) {
   } else {
     parallel_normalize();
   }
+
+  //  mlog_dump("memlog.good");
 
   return get(0);
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define DEBUG
+//#define DEBUG
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
@@ -201,14 +201,14 @@ static Book BOOK = {
 
 // Local Thread Memory
 typedef struct TM {
-  u32 tid;  // thread id
-  Loc nput; // next node allocation attempt index
-  Loc rput; // next rbag push index
-  Loc bput; // next (owned) bbag push index
-  Loc bpop; // next (stolen) bbag pop index
-  u32 sid; // tid from which bbag was stolen
-  u32 sgud; // successful steals
-  u32 sbad; // failed steals
+  u32 tid;   // thread id
+  Loc nput;  // next node allocation attempt index
+  Loc rput;  // next rbag push index
+  Loc bput;  // owned) bbag push index
+  u32 sid;   // tid from which bbag was stolen
+  Loc spop;  // stolen bbag pop index + 2
+  u32 sgud;  // successful steal count
+  u32 sbad;  // failed steal count
 
   // debugging
   u32 mput;
@@ -216,7 +216,7 @@ typedef struct TM {
   u32 i1_tag;
   u32 i2_tag;
 
-  u64 itrs; // interaction count
+  u64 itrs;  // interaction count
   bool buse; // use booty bag
   bool bful; 
 } TM;
@@ -450,7 +450,7 @@ TM *tm_new(u64 tid) {
   tm_reset(tm);
   tm->tid = tid;
   tm->bput = 0;
-  tm->bpop = 0;
+  tm->spop = 0;
   tm->sid = TPC;
   tm->sgud = 0;
   tm->sbad = 0;
@@ -530,7 +530,7 @@ static Term term_offset_loc(Term term, Loc offset) {
 
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
-static int bty_debug = 0; // booty bag
+static int bty_debug = 1; // booty bag
 
 static const char* term_str(char* buf, Term term) {
   sprintf(buf, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
@@ -635,6 +635,7 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   if (tm->nput + cnt >= NODE_LEN) {
     fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
             tm->tid, tm->nput, cnt, NODE_LEN);
+    //fflush(stderr);
     exit(1);
   }
 
@@ -660,8 +661,18 @@ static u32 bbag_get(u32 tid) {
 static Loc get_push_offset(TM *tm) {
   // Only push to booty bag if we aren't stealing
   if (tm->buse && !tm->bful && (tm->bput < BBAG_LEN) && (tm->sid == TPC)) {
+
+#ifdef DEBUG
+  fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
+#endif
+
     return tm->bput;
   }
+
+#ifdef DEBUG
+  fprintf(stderr, "%u pushing to RBAG @ %u\n", tm->tid, tm->rput);
+#endif
+
   // Push to RBAG
   return BBAG_LEN + tm->rput;
 }
@@ -689,15 +700,15 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 }
 
 static Pair rbag_pop(TM* tm) {
-  if (tm->bpop > 0) {
+  if (tm->spop > 0) {
     // Pop from stolen, non-empty booty bag
-    tm->bpop -= 2;
+    tm->spop -= 2;
 
     // If we are stealing from our own booty bag, adjust push index as well
     if (tm->sid == tm->tid) {
       tm->bput -= 2;
     }
-    return bbag_ini(tm->sid) + tm->bpop;
+    return bbag_ini(tm->sid) + tm->spop;
   } else if (tm->rput > 0) {
     // Pop from non-empty RBAG
     tm->rput -= 2;
@@ -1663,16 +1674,24 @@ static bool try_steal(TM *tm) {
     // TODO: combine these two conditions into one compound condition
     if (tm->bput < BBAG_LEN) {
       // Booty bag isn't full, so we can steal without atomics
-      tm->bpop = tm->bput;
+      tm->spop = tm->bput;
       tm->sid = tm->tid;
+
+#ifdef DEBUG
+      fprintf(stderr, "%u stealing own non-empty booty bag\n", tm->tid);
+#endif
 
       return true;
     } else {
       // To steal from our own full bag, we need to atomic swap
       if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
-        tm->bpop = tm->bput; // will always be BBAG_LEN
-        tm->sid = tm->tid;
         tm->bful = false;
+        tm->spop = tm->bput; // will always be BBAG_LEN
+        tm->sid = tm->tid;
+
+#ifdef DEBUG
+        fprintf(stderr, "%u stole own full booty bag\n", tm->tid);
+#endif
 
         return true;
       }
@@ -1683,9 +1702,14 @@ static bool try_steal(TM *tm) {
   // Try to steal another thread's full bag
   u32 vic = get_victim(tm);
   if (bbag_compare_swap(vic, FULL, STOLEN, memory_order_acquire)) {
-    tm->bpop = BBAG_LEN;
+    tm->spop = BBAG_LEN;
     tm->sid = vic;
     tm->sgud += 1;
+
+#ifdef DEBUG
+    fprintf(stderr, "%u stole t%u's booty bag\n", tm->tid, tm->sid);
+#endif
+
     return true;
   }
 
@@ -1706,13 +1730,26 @@ static bool timeout(u32 tick) {
 static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
   Pair pair = take_pair(loc, from_bty);
 
-  if (from_bty && (tm->bpop == 0) && (tm->sid != tm->tid)) {
-    // The last pair was just popped from a stolen booty bag
-    bbag_set(tm->sid, EMPTY, memory_order_relaxed);
+  if (from_bty && (tm->spop == 0)) {
+    // The booty bag we stole just became empty
+
+    if (tm->sid != tm->tid) {
+      // It was another threads bag - signal that it can be recovered now
+      bbag_set(tm->sid, EMPTY, memory_order_relaxed);
+
+#ifdef DEBUG
+      fprintf(stderr, "%u emptied t%u's stolen booty bag\n", tm->tid, tm->sid);
+#endif
+    } else {
+#ifdef DEBUG
+      fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
+#endif
+    }
+
+    // No longer stealing
     tm->sid = TPC;
-    tm->bful = false;
   }
-  
+
   interact(tm, pair_neg(pair), pair_pos(pair));
 }
 
@@ -1729,7 +1766,7 @@ static void* thread_func(void* arg) {
   while (true) {
     tick += 1;
 
-    bool from_bty = tm->bpop > 0; // haxor
+    bool from_bty = tm->spop > 0; // haxor
     // TODO: I think i can adjust rbag_pop() to not include RBAG, and thus pass
     // down the "loc < BBAG_LEN" logic to here in order to determine if this
     // was a booty-bag pop. That'll move some tid vs. sid logic here though.
@@ -1739,17 +1776,22 @@ static void* thread_func(void* arg) {
 
       // We *think* booty bag is full, but it may have been stolen and emptied
       if (tm->bful && (bbag_get(tm->tid) == EMPTY)) {
-        tm->bput = 0;
-        tm->sid = TPC;
         tm->bful = false;
+        tm->bput = 0;
+
+#ifdef DEBUG
+        fprintf(stderr, "%u recovered stolen, empty booty bag\n", tm->tid);
+#endif
+        //tm->sid = TPC;
       }
 
       take_and_interact(tm, loc, from_bty);
 
       if (!tm->bful && (tm->bput == BBAG_LEN)) {
         // Booty bag was filled by the preceding interaction
+
+        // Signal that it can be stolen aka drop()
         bbag_set(tm->tid, FULL, memory_order_release);
-        tm->sid = TPC; // weird
         tm->bful = true;
       }
     } else {
@@ -1766,8 +1808,8 @@ static void* thread_func(void* arg) {
   atomic_fetch_add(&net.itrs, tm->itrs);
 
   if (1) {
-    fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, bpop: %u, steals: %u good %u bad\n",
-            tm->tid, tm->itrs, tm->rput, tm->bput, tm->bpop, tm->sgud, tm->sbad);
+    fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, spop: %u, steals: %u good %u bad\n",
+            tm->tid, tm->itrs, tm->rput, tm->bput, tm->spop, tm->sgud, tm->sbad);
   }
   return NULL;
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -227,7 +227,7 @@ void dump_buff(TM *tm);
 static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
 
-#define MEMLOG // comment out to disable
+//#define MEMLOG // comment out to disable
 
 #ifdef MEMLOG
 
@@ -267,6 +267,7 @@ static void mlog_free() {
 }
 
 // i1_tag: 4, i2_tag: 4, lvl: 5, op:2, t1_tag: 4, t2_tag: 4, tid: 4, sid: 4
+
 static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
                       u32 i1_tag, u32 i2_tag, u32 t1_tag, u32 t2_tag) {
   u64 hi = (i1_tag << 27) | ((i2_tag & 0xF) << 23) |
@@ -553,15 +554,10 @@ void set(Loc loc, Term term) {
 }
 
 static Pair take_pair(Loc loc) {
-#if 0 || defined(ATOMIC)
-  #define VOID_TEST
-  Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], VOID, __ATOMIC_RELAXED);
-#else
   Pair pair = *(Pair*)&BUFF[loc];
   //#define VOID_TEST
 #ifdef VOID_TEST
   *(Pair*)&BUFF[loc] = (Pair)VOID;
-  #endif
 #endif
 
 #ifdef VOID_TEST
@@ -571,31 +567,11 @@ static Pair take_pair(Loc loc) {
   }
 #endif
   
-#if 0 || defined(DEBUG)
-  if (mop_debug) {
-    char buf[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d take.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
-    fprintf(stderr, "%d take.pos %u %s\n", thread_id, loc + 1, term_str(buf, pair_pos(pair)));
-  }
-#endif
-
   return pair;
 }
 
 static void set_pair(Loc loc, Pair pair) {
-#ifdef ATOMIC
-  __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
-#else
   *((Pair*)&BUFF[loc]) = pair;
-#endif
-
-#if 0 || defined(DEBUG)
-  if (mop_debug) {
-    char buf[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d set.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
-    fprintf(stderr, "%d set.pos %u %s\n", thread_id, loc + 1, term_str(buf, pair_pos(pair)));
-  }
-#endif
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -604,12 +580,6 @@ static Loc port(u64 n, Loc loc) { return n + loc - 1; }
 // ---------
 
 static Loc node_alloc(TM *tm, u32 num) {
-#ifdef DEBUG
-  if (mop_debug) {
-    fprintf(stderr, "%u alloc %u nodes at %u\n", tm->tid, num, tm->nput);
-  }
-#endif
-
   if ((num & 1) == 1) {
     num += 1;
   }
@@ -633,39 +603,15 @@ static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
   u32 orig = expect;
   bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
                  desire, success_order, memory_order_relaxed);
-
-  if (bty_debug) {
-    if (res) {
-      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s succeeded\n",
-              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire));
-    }
-    else if (0) {
-      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s failed, it's %s\n",
-              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire),
-              bty_ctrl_str(expect));
-    }
-  }
-
   return res;
 }
 
 static void bbag_set(u32 tid, u32 val, memory_order order) {
   atomic_store_explicit(&bbs[tid]->ctrl, val, order);
-
-  if (bty_debug) {
-    fprintf(stderr, "%d set t%u's booty bag to %s\n", thread_id, tid,
-            bty_ctrl_str(val));
-  }
 }
 
 static u32 bbag_get(u32 tid) {
   u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
-
-  if (0 && bty_debug) {
-    fprintf(stderr, "%d got t%u's booty bag: %s\n", thread_id, tid,
-            bty_ctrl_str(got));
-  }
-
   return got;
 }
 
@@ -676,11 +622,6 @@ static Loc get_push_offset(TM *tm) {
       // BBAG is full, last we checked. But maybe it's empty now
       if (bbag_get(tm->tid) == EMPTY) {
         tm->bput = 0;
-
-        if (bty_debug) {
-          fprintf(stderr, "%u own booty bag is newly empty\n", tm->tid);
-        }
-
         return tm->bput;
       }        
     } else {
@@ -698,39 +639,14 @@ static Loc rbag_push(TM *tm, Term neg, Term pos) {
   bool bty = off < BBAG_LEN;
   Loc loc = RBAG + tm->tid * RBAG_LEN + off;
 
-#ifdef DEBUG
-  if (mop_debug) {
-    fprintf(stderr, "%u calling set_pair @ %u, rput %u\n", tm->tid, loc,
-            tm->rput);
-  }
-#endif
-
   set_pair(loc, pair_new(neg, pos));
 
   if (bty) {
-    //MLOG(MOP_STOR, tm->tid, tm->bput, pair_neg(pair), pair_pos(pair));
-    //MLOG(MOP_STOR, tm->tid, tm->bput, neg, pos);
-
-    if (1 && bty_debug) {
-      fprintf(stderr, "%u pushed to booty bag @ %u\n", tm->tid, tm->bput);
-      char buf[TERMSTR_BUFSIZ];
-      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
-      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
-      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, neg));
-      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pos));
-    }
-
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
       bbag_set(tm->tid, FULL, memory_order_release);
-
-      if (0 && bty_debug) {
-        fprintf(stderr, "%u booty bag full\n", tm->tid);
-      }
     }
   } else {
-    //MLOG(MOP_STOR, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
-
     //#ifdef DEBUG
     bool free_global = tm->rput < RBAG_LEN - BBAG_LEN - 1;
     if (!free_global) {
@@ -744,12 +660,6 @@ static Loc rbag_push(TM *tm, Term neg, Term pos) {
   return loc;
 }
 
-/*
-static void rbag_push(TM *tm, Term neg, Term pos) {
-  redex_push(tm, pair_new(neg, pos));
-}
-*/
-
 static Pair rbag_pop(TM* tm) {
   if (tm->bpop > 0) {
     // We stole a booty bag, use it
@@ -758,19 +668,6 @@ static Pair rbag_pop(TM* tm) {
     // If stealing from own booty bag, adjust push index as well
     if (tm->btid == tm->tid) {
       tm->bput -= 2;
-
-      #if 0
-      // Debugging
-      if (tm->bput != tm->bpop) {
-        fprintf(stderr, "bput: %u, bpop: %u\n", tm->bput, tm->bpop);
-        exit(1);
-      }
-      #endif
-    }
-
-    if (bty_debug) {
-      fprintf(stderr, "%u popping from t%u's booty bag @ %u\n", tm->tid,
-              tm->btid, tm->bpop);
     }
 
     return RBAG + tm->btid * RBAG_LEN + tm->bpop;
@@ -929,10 +826,10 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   Term root = term_offset_loc(nodes[0], offset);
 
   // No redexes reference these nodes yet; safe to add without atomics.
-  // TODO: ensure nodes always 16-byte aligned to enable 128-bit stores
   u32 n = 1;
   for (; n + 1 < nodes_len; n += 2) {
     Loc loc = offset + n;
+    // 128-bit load & store
     Pair pair = *(Pair*)&nodes[n];
     *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
                                   term_offset_loc(pair_pos(pair), offset));
@@ -969,7 +866,6 @@ static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
     Loc loc = term_loc(pos);
     Term far = swap_lvl(loc, neg, lvl);
-    //MLOG_LVL(MOP_EXCH, tm->tid, lvl, loc, far, neg);
     if (term_tag(far) != SUB) {
       move_lvl(tm, term_loc(pos), far, lvl + 1, neg);
     }
@@ -985,7 +881,6 @@ static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl, Term exp_neg
     fprintf(stderr, "OOF\n");
   }
 #endif
-  //MLOG_LVL(MOP_EXCH, tm->tid, lvl, neg_loc, neg, pos);
   if (term_tag(neg) != SUB) {
     // No need to take() since we already swapped
     link_lvl(tm, neg, pos, lvl + 1);
@@ -1007,14 +902,13 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
 
+  // Magic to make race condition appear more frequently
   bool buse = tm->buse;
   tm->buse = false;
-  //  tm->muse = true;
 
   move(tm, var, arg);
   move(tm, ret, bod);
 
-  //  tm->muse = false;
   tm->buse = buse;
 }
 
@@ -1633,12 +1527,6 @@ static void sync_threads() {
 static bool set_idle(bool was_busy) {
   if (was_busy) {
     u32 idle = atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
-
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u set idle, was idle = %u\n", thread_id, idle);
-    }
-#endif
   }
   return false;
 }
@@ -1646,12 +1534,6 @@ static bool set_idle(bool was_busy) {
 static bool set_busy(bool was_busy) {
   if (!was_busy) {
     u32 idle = atomic_fetch_sub_explicit(&net.idle, 1, memory_order_relaxed);
-
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u set busy, was idle = %u\n", thread_id, idle);
-    }
-#endif
   }
   return true;
 }
@@ -1669,30 +1551,13 @@ static bool try_steal(TM *tm) {
       // Booty bag isn't full, so we can steal without atomics
       tm->bpop = tm->bput;
       tm->btid = tm->tid;
-
-      if (0 && bty_debug) {
-        fprintf(stderr, "%u stealing own non-full booty bag, len = %u\n",
-                tm->tid, tm->bpop);
-      }
-
       return true;
     } else {
       // To steal from our own full bag, we need to take back ownership
       if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
         tm->bpop = tm->bput; // BBAG_LEN, always
         tm->btid = tm->tid;
-
-        if (0 && bty_debug) {
-          fprintf(stderr, "%u stealing own full booty bag, len = %u\n",
-                  tm->tid, tm->bpop);
-        }
-
         return true;
-      } else {
-        if (0 && bty_debug) {
-          fprintf(stderr, "%u failed to steal own full booty bag\n",
-                  tm->tid); //, bty_ctrl_str(state));
-        }
       }
     }
   }
@@ -1704,11 +1569,6 @@ static bool try_steal(TM *tm) {
     tm->bpop = BBAG_LEN;
     tm->btid = vic;
     tm->sgud += 1;
-
-    if (0 && bty_debug) {
-      fprintf(stderr, "%u stealing t%u's booty bag, \n", tm->tid, tm->btid);
-    }
-
     return true;
   }
 
@@ -1722,11 +1582,6 @@ static bool check_timeout(u32 tick) {
     if (idle == TPC) {
      return true;
     }
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u idle, total: %u\n", thread_id, idle);
-    }
-#endif
   }
   return false;
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -141,13 +141,13 @@ enum : u64 {
   ZERO = 0,
 
   // Threads per CPU
-  TPC = 2,
+  TPC = 4,
 
   // Number of terms *per thread* for each overflow bag. There are two of them,
   // and they (currently) steal space from each thread's RBAG space.
   // NB: These numbers are a bit aggresive. Overflow of overflow could happen.
-  OFLW_LEN = 2048,
-  OFLW_SYNC = OFLW_LEN / 2,
+  OFLW_LEN = 1024,
+  OFLW_SYNC = OFLW_LEN,
 
   // Various redex bag sizes within the heap to choose from. The remaining
   // percentage is used for node storage.
@@ -830,7 +830,8 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
   } else if (off >= OFLW_INI) {
     // pushed to overflow
     if (tm->oput[tm->opid] >= OFLW_LEN-1) {
-      fprintf(stderr, "%u overflow %u space exhausted\n", tm->tid, tm->opid);
+      fprintf(stderr, "%u overflow %u space exhausted @ %u\n", tm->tid,
+              tm->opid, tm->oput[tm->opid]);
       exit(1);
     }
     tm->oput[tm->opid] += 2;
@@ -846,23 +847,38 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
 
 static Loc redex_pop_loc(TM* tm) {
   // Must check overflow bag first when sync'd
-  if (tm->ouse && tm->osyn) {
-    u32 oidx = 1u - tm->opid;
-    u32 oput = tm->oput[oidx];
-    if (oput > 0) {
-      oput -= 2;
-      tm->oput[oidx] = oput;
+  if (tm->ouse) {
 
-      #if 0 || defined(DEBUG)
-      if (oflw_debug) {
-        fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
-                oidx, oput);
+    if (tm->osyn) {
+      // Overflow is sync'd so we can pop
+      u32 oidx = 1u - tm->opid;
+      u32 oput = tm->oput[oidx];
+      if (oput > 0) {
+        oput -= 2;
+        tm->oput[oidx] = oput;
+        
+        #if 0 || defined(DEBUG)
+        if (oflw_debug) {
+          fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
+                  oidx, oput);
+        }
+        #endif
+        
+        return oflw_ini(tm->tid, oidx) + oput;
       }
-      #endif
-
-      return oflw_ini(tm->tid, oidx) + oput;
     }
-  } 
+
+    // If the overflow put bag is full, don't allow any pops from anywhere.
+    // Overflow will empty on next sync.
+    u32 oput = tm->oput[tm->opid];
+    u32 opop = tm->oput[1-tm->opid] / 2;
+    if (oput+opop >= OFLW_LEN) {
+      //fprintf(stderr, "%u no pops overflow %u full\n", tm->tid, tm->opid);
+      return 0;
+    }
+
+  }
+    
   if (tm->spop > 0) {
     // Pop from stolen, non-empty booty bag
     tm->spop -= 2;
@@ -903,7 +919,7 @@ void hvm_init() {
   fprintf(stderr, "NODE_LEN  = %u\n", NODE_LEN);
   #endif
 
-  //signal(SIGSEGV, segv_handler);
+  signal(SIGSEGV, segv_handler);
 
 #ifdef MEMLOG
   mlog_init();
@@ -1854,30 +1870,41 @@ struct SIMPLE_SYNC {
   a64 departed;
 } ss;
 
-static bool sync_start(u32 tid) {
+static bool sync_arrive(u32 tid) {
   u64 prev_arrived = atomic_fetch_add_explicit(&ss.arrived, 1, memory_order_relaxed);
   if (prev_arrived + 1 == TPC) {
     // Last to arrive
+    atomic_store_explicit(&ss.departed, 1ULL, memory_order_release);
     atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
-    atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
     return true;
   }
   return false;
 }
 
-static bool sync_wait(bool departed) {
-  u64 dep_cnt = 0;
+_Thread_local u32 nsync = 0;
+
+static bool sync_depart(bool departed) {
   if (!departed) {
-    dep_cnt = atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
-  } else {
-    dep_cnt = atomic_load_explicit(&ss.departed, memory_order_relaxed);
+    if (atomic_load_explicit(&ss.arrived, memory_order_relaxed) > 0) {
+      return false;
+    }
+    /*u64 dep_cnt = */atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
+    //technically a "sync done" shortcut for 1 person here, i just dont know
+    // how to return it.
   }
-  if ((dep_cnt % TPC) == 0) {
-    atomic_thread_fence(memory_order_acquire);
-    return false;
-  } else {
-    return true;
+  return true;
+}
+
+static bool sync_wait(bool departed) {
+  if (departed) {
+    u64 dep_cnt = atomic_load_explicit(&ss.departed, memory_order_relaxed);
+    if ((dep_cnt % TPC) == 0) {
+      nsync += 1;
+      atomic_thread_fence(memory_order_acquire);
+      return false;
+    }
   }
+  return true;
 }
 
 static void* thread_func(void* arg) {
@@ -1904,38 +1931,40 @@ static void* thread_func(void* arg) {
     tick += 1;
 
     if (tm->ouse) {
-      if ((tick % OFLW_SYNC) == 0) {
-        if (!syncing) {
-          departed = sync_start(tm->tid);
-          syncing = true;
-
-          if (oflw_debug) {
-            fprintf(stderr, "%u syncing, stop taking from overflow %u oput %u\n",
-                    tm->tid, 0u+tm->opid, tm->oput[tm->opid]);
-          }
-          
-          // TODO: assert(oput[oidx] == 0);
-          tm->opid = 1 - tm->opid;
-          // Just in case it's not empty (it should be)
-          //tm->otak = false;
-          tm->osyn = false;
+      u64 tick_mod = tick % OFLW_SYNC;
+      if ((tick_mod == 0) && !syncing) {
+        departed = sync_arrive(tm->tid);
+        syncing = true;
+        
+        if (0 || oflw_debug) {
+          fprintf(stderr, "%u syncing @ %u, stop taking from overflow %u len %u\n",
+                  tm->tid, nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
         }
+        
+        // TODO: assert(oput[oidx] == 0);
+        tm->opid = 1 - tm->opid;
+        // Just in case it's not empty (it should be)
+        //tm->otak = false;
+        tm->osyn = false;
       } else if (syncing) {
+        departed = sync_depart(departed);
         syncing = sync_wait(departed);
-        departed = true;
         if (!syncing) {
-
-          if (oflw_debug) {
-            fprintf(stderr, "%u sync'd, can take from overflow %u size %u\n",
-                    tm->tid, 1u-tm->opid, tm->oput[1u-tm->opid]);
-          }
-
-          //tm->otak = true;
           tm->osyn = true;
+          //tm->otak = true;
           // Reset tick count to ensure we empty oveflow before next sync point
           // TODO: could also try something like:
-          //       if ((tick % sync) < oput[1-oidx]) tick = sync - oput[1-oidx]
-          tick = 0;
+          //if ((tick % sync) < oput[1-oidx]) 
+          // just enough rope to hang ourselves
+          u32 oflw_len = (tm->oput[1-tm->opid] / 2);
+          if (tick_mod < oflw_len) {
+            tick = OFLW_SYNC - oflw_len;
+          }
+          //tick = 0;
+          if (0 || oflw_debug) {
+            fprintf(stderr, "%u synched @ %u, can take from overflow %u len %u tick %" PRIu64 "\n",
+                    tm->tid, nsync, 1u-tm->opid, tm->oput[1u-tm->opid]/2, tick);
+          }
         }
       }
     }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -1520,7 +1520,6 @@ static void* thread_func(void* arg) {
   // Wait until after injection to turn these on
   tm->buse = true;
   tm->duse = true;
-  //u64 do_nothing = 0;
 
   __attribute__((unused))
   u64  fst_steal = 0;
@@ -1548,7 +1547,6 @@ static void* thread_func(void* arg) {
 
       interact(tm, pair_neg(pair), pair_pos(pair));
     } else {
-      //do_nothing += 1;
       if (busy && can_idle(tm)) {
         busy = set_idle(busy);
       }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -135,7 +135,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 8
+  BBAG_LEN = 96
 };
 
 typedef struct Net {
@@ -725,6 +725,9 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   }
   #endif
 
+  bool buse = tm->buse;
+  tm->buse = false;
+
   for (u32 i = 0; i < rbag_len; i += 2) {
 #if 1 // old
     Term neg = term_offset_loc(rbag[i], offset);
@@ -737,6 +740,9 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     //redex_push(tm, pair); 
 #endif
   }
+
+  tm->buse = buse;
+
   return root;
 }
 
@@ -768,6 +774,7 @@ static inline void move(TM *tm, Loc neg_loc, Term pos) {
   Term neg = swap(neg_loc, pos);
   if (term_tag(neg) != SUB) {
     // No need to take() since we already swapped
+    //set(neg_loc, 0);
     link_terms(tm, neg, pos);
   }
 }
@@ -778,10 +785,13 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
+
   bool buse = tm->buse;
-  tm->buse = false;
+  //tm->buse = false;
+
   move(tm, var, arg);
   move(tm, ret, bod);
+
   tm->buse = buse;
 }
 
@@ -1162,6 +1172,9 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
     exit(1);
   }
 
+  bool buse = tm->buse;
+  tm->buse = false;
+
   u32 i_arm = (n < mat_len - 1) ? n : (mat_len - 1);
   for (u32 i = 0; i < mat_len; i++) {
     if (i != i_arm) {
@@ -1182,6 +1195,8 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
 
     link_terms(tm, term_new(APP, 0, app), arm);
   }
+
+  tm->buse = buse;
 }
 
 static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -1,9 +1,11 @@
 // HVM3-Strict Core: parallel, polarized, LAM/APP & DUP/SUP only
 
 #include <assert.h>
+#include <execinfo.h>
 #include <inttypes.h>
 #include <math.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -29,6 +31,16 @@ int thread_create(pthread_t *thread, const pthread_attr_t *attr,
 
 int thread_join(pthread_t thread, void **retval) {
   return pthread_join(thread, retval);
+}
+
+void segv_handler(int sig) {
+  void *array[10];
+  size_t size;
+  
+  size = backtrace(array, 10);
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
 }
 
 // Constants
@@ -135,7 +147,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 96
+  BBAG_LEN = 8
 };
 
 typedef struct Net {
@@ -313,16 +325,6 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
-static Term term_offset_loc2(Term term, Loc offset) {
-  Tag tag = term_tag(term);
-  if (tag == SUB || tag == NUL || tag == ERA || tag == REF || tag == U32) {
-    return term;
-  } else {
-    Loc loc = term_loc(term) + offset;
-    return (((Term)loc) << 32) | (term & 0xFFFFFFFF);
-  }
-}
-
 //#define DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
@@ -409,11 +411,7 @@ static Pair take_pair(Loc loc) {
 }
 
 static void set_pair(Loc loc, Pair pair) {
-#ifdef ATOMIC
-  __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
-#else
   *((Pair*)&BUFF[loc]) = pair;
-#endif
 
 #if 0 || defined(DEBUG)
   if (mop_debug) {
@@ -429,6 +427,10 @@ static Loc port(u64 n, Loc loc) { return n + loc - 1; }
 // Allocator
 // ---------
 
+static Loc rnod_ini(u32 tid) {
+  return tid * NODE_LEN;
+}
+
 static Loc node_alloc(TM *tm, u32 cnt) {
 #ifdef DEBUG
   if (mop_debug) {
@@ -437,9 +439,7 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   }
 #endif
 
-  if ((cnt & 1) == 1) {
-    cnt += 1;
-  }
+  //cnt += (cnt & 1);
 
   if (tm->nput + cnt >= NODE_LEN) {
     fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
@@ -447,7 +447,7 @@ static Loc node_alloc(TM *tm, u32 cnt) {
     exit(1);
   }
 
-  Loc loc = tm->tid * NODE_LEN + tm->nput;
+  Loc loc = rnod_ini(tm->tid) + tm->nput;
   tm->nput += cnt;
   return loc;
 }
@@ -482,18 +482,6 @@ static Loc get_push_offset(TM *tm) {
       // Booty bag isn't full, push to it
       return tm->bput;
     }
-    /*
-    else {
-      // Booty bag is full
-      if (0 && !tm->bfld) {
-        // It wasn't filled during this interaction
-        if (bbag_get(tm->tid) == EMPTY) {
-          tm->bput = 0;
-          return tm->bput;
-        }
-      }
-    }
-    */
   }
   // Push to RBAG
   return BBAG_LEN + tm->rput;
@@ -567,6 +555,8 @@ void hvm_init() {
 
   alloc_static_data();
 
+  signal(SIGSEGV, segv_handler);
+
   #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
   fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
@@ -586,16 +576,9 @@ void hvm_free() {
 
 Loc ffi_alloc_node(u64 arity) {
   TM *tm = tms[0];
-#if 1
   Loc loc = tm->nput;
-  //if ((arity & 1) == 1) {
-  //  arity += 1;
-  //}
   tm->nput += arity;
   return loc;
-#else
-  return node_alloc(tm, arity);
-#endif
 }
 
 void ffi_rbag_push(Term neg, Term pos) {
@@ -606,18 +589,94 @@ u64 inc_itr() {
   return atomic_load(&net.itrs);
 } 
 
-Loc rbag_ini() {
+Loc ffi_rbag_ini() {
   // TODO
   return RBAG;
 }
 
-Loc rbag_end() {
+Loc ffi_rbag_end() {
   // TODO
   return RBAG;
 }
 
-Loc rnod_end() {
-  return net.nods;
+Loc ffi_rnod_end() {
+  return atomic_load(&net.nods);
+}
+
+static Loc bbag_offset(u32 tid) {
+  return tid * RBAG_LEN;
+}
+
+static Loc bbag_ini(u32 tid) {
+  return RBAG + bbag_offset(tid);
+}
+
+static Loc rbag_ini(u32 tid) {
+  return bbag_ini(tid) + BBAG_LEN;
+}
+
+static u64 align(u64 align, u64 val) {
+  return (val + align - 1) & ~(align - 1);
+}
+
+int cmp_u32(const void *a, const void *b) {
+  u32 aa = *(const u32*)a;
+  u32 bb = *(const u32*)b;
+  return (aa > bb) - (bb < aa);
+}
+
+u32 upr_bnd(Loc *locs, u32 cnt, Loc tgt) {
+  u32 lft = 0;
+  u32 rgt = cnt;
+  while (lft < rgt) {
+    u32 mid = lft + (rgt - lft) / 2;
+    if (locs[mid] > tgt) {
+      rgt = mid;
+    } else {
+      lft = mid + 1;
+    }
+  }
+  return lft;
+}
+
+u32 dup_bod(Term *src, Term *dst, u32 nsrc) {
+  Term lam = src[0];
+  if (term_tag(lam) != LAM) return 0;
+
+  Term arg = src[1];
+  // Don't know how to deal with this.
+  if (term_tag(arg) == MAT) return 0;
+
+  Term bod = src[2];
+  if (term_tag(bod) != VAR) return 0;
+  
+  Loc bod_loc = term_loc(bod);
+  // Another weird case I can't deal with.
+  if (bod_loc < 2) return 0;
+
+  Loc *locs = (Loc *)(dst + nsrc * 2);
+  *locs = bod_loc;
+  
+  u32 nloc = 1;
+
+  // Copy all terms, updating their locs, and duplicating terms at
+  // locations in locs array
+  for (u32 i = 0, loc_idx = 0; i < nsrc; i++) {
+    Term trm = src[i];
+    if (term_has_loc(trm)) {
+      Loc loc = term_loc(trm);
+      if (loc > *locs) {
+        loc += 1;
+      }
+      trm = term_with_loc(trm, loc);
+    }
+    dst[i + loc_idx] = trm;
+    if ((loc_idx < nloc) && (i == locs[loc_idx])) {
+      loc_idx += 1;
+      dst[i + loc_idx] = trm;
+    }
+  }
+  return nloc;
 }
 
 // Moves the global buffer and redex bag into a new def and resets
@@ -629,37 +688,59 @@ void def_new(char *name) {
     } else {
       BOOK.cap *= 2;
     }
-
     BOOK.defs = realloc(BOOK.defs, sizeof(Def) * BOOK.cap);
   }
 
   TM *tm = tms[0];
 
-  Loc rbag_end = tm->rput;
-  Loc rnod_end = tm->nput;
-  size_t rbag_siz = ((sizeof(Term) * rbag_end) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
-  size_t rnod_siz = ((sizeof(Term) * rnod_end) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
+  Loc rnod_cnt = tm->nput;
+  Loc rbag_cnt = tm->rput;
+
+  u32 node_ini = align(CACH_SIZ, rnod_cnt);
+  // assert((mnod_ini + rnod_cnt * 3) < RBAG);
+  Term *nodes = &BUFF[node_ini];
+
+  u32 ndup = dup_bod(BUFF, nodes, rnod_cnt);
+
+  if (ndup == 0) {
+    nodes = BUFF;
+  } else {
+    rnod_cnt += ndup;
+  }
+
+  u64 rbag_siz = align(CACH_SIZ, sizeof(Term) * rbag_cnt);
+  u64 rnod_siz = align(CACH_SIZ, sizeof(Term) * rnod_cnt);
 
   Def def = {
       .name = name,
       .nodes = aligned_alloc(CACH_SIZ, rnod_siz),
-      .nodes_len = rnod_end,
+      .nodes_len = rnod_cnt,
       .rbag = aligned_alloc(CACH_SIZ, rbag_siz),
-      .rbag_len = rbag_end,
+      .rbag_len = rbag_cnt,
   };
 
   if (def.nodes == NULL || def.rbag == NULL) {
     fprintf(stderr, "DEF memory allocation failed\n");
+    exit(1);
   }
 
-  u64 *rbag = BUFF + RBAG + BBAG_LEN;
+  Term *rbag = &BUFF[rbag_ini(0)];
 
-  memcpy(def.nodes, BUFF, sizeof(Term) * def.nodes_len);
+  memcpy(def.nodes, nodes, sizeof(Term) * def.nodes_len);
   memcpy(def.rbag, rbag, sizeof(Term) * def.rbag_len);
 
-  // printf("NEW DEF '%s':\n", def.name);
-  // dump_buff();
-  // printf("\n");
+#if 0
+  if (ndup) {
+    if (ndup) {
+      memcpy(BUFF, nodes, sizeof(Term) * def.nodes_len);
+      tm->nput = def.nodes_len;
+    }
+
+    printf("NEW DEF '%s':\n", def.name);
+    dump_buff();
+    printf("\n");
+  }
+#endif
 
   memset(BUFF, 0, sizeof(Term) * def.nodes_len);
   memset(rbag, 0, sizeof(Term) * def.rbag_len);
@@ -700,44 +781,16 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   Term root = term_offset_loc(nodes[0], offset);
 
   // No redexes reference these nodes yet; safe to add without atomics
-#define NODE_128
-#ifndef NODE_128 // old
   for (u32 n = 1; n < nodes_len; n++) {
     Loc loc = offset + n;
     Term term = term_offset_loc(nodes[n], offset);
     BUFF[loc] = term;
   }
-#else
-  u32 n = 1;
-  for (; n + 1 < nodes_len; n += 2) {
-    Loc loc = offset + n;
-    // 128-bit load & store
-    Pair pair = *(Pair*)&nodes[n];
-    *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
-                                  term_offset_loc(pair_pos(pair), offset));
-  }
-  if (n < nodes_len) {
-    BUFF[offset + n] = term_offset_loc(nodes[n], offset);
-  }
-#endif
 
-#if 0
   for (u32 i = 0; i < rbag_len; i += 2) {
-#else
-  // reverse order
-  for (int i = rbag_len - 2; i >= 0; i -= 2) {
-#endif
-
-#ifndef NODE_128 // old
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i + 1], offset);
     rbag_push(tm, neg, pos);
-#else
-    // 128-bit load
-    Pair pair = *(Pair*)&rbag[i];
-    rbag_push(tm, term_offset_loc(pair_neg(pair), offset),
-              term_offset_loc(pair_pos(pair), offset));
-#endif
   }
   return root;
 }
@@ -753,11 +806,27 @@ static void boot(Loc def_idx) {
 }
 
 // Atomic Linker
+static Term get_loop(Loc loc) {
+  fprintf(stderr, "get_loop\n");
+  // TOOD: tick/timeout
+  while (1) {
+    Term term = get(loc);
+    if (term == 0) {
+      sched_yield();
+    } else {
+      return term;
+    }
+  }
+}
+
 static inline void move(TM *tm, Loc neg_loc, u64 pos);
 
 static inline void link_terms(TM *tm, Term neg, Term pos) {
   if (term_tag(pos) == VAR) {
     Term far = swap(term_loc(pos), neg);
+    if (far == 0) {
+      far = get_loop(term_loc(pos + 1));
+    }
     if (term_tag(far) != SUB) {
       move(tm, term_loc(pos), far);
     }
@@ -781,8 +850,14 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
+
+  bool buse = tm->buse;
+  tm->buse = false;
+
   move(tm, var, arg);
   move(tm, ret, bod);
+
+  tm->buse = buse;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1592,7 +1667,7 @@ static char *bty_ctrl_str(u32 ctrl) {
 
 static void dump_term(Loc loc) {
   Term term = get(loc);
-  printf("%06X %03X %03X %s\n", loc, term_loc(term), term_lab(term),
+  printf("%04u %03u %03u %s\n", loc, term_loc(term), term_lab(term),
       tag_to_str(term_tag(term)));
 }
 
@@ -1641,21 +1716,20 @@ static void dump_term(Loc loc) {
 void tm_dump_buff(TM *tm) {
   printf("------------------\n");
   printf("      NODES\n");
-  printf("ADDR   LOC LAB TAG\n");
+  printf("ADDR LOC LAB TAG\n");
   printf("------------------\n");
   for (Loc idx = 0; idx < tm->nput; idx++) {
-    Loc loc = tm->tid * NODE_LEN + idx;
-    dump_term(loc);
+    dump_term(rnod_ini(tm->tid) + idx);
   }
   printf("------------------\n");
   printf("    REDEX BAG\n");
   printf("ADDR   LOC LAB TAG\n");
   printf("------------------\n");
   for (Loc idx = 0; idx < tm->rput; idx++) {
-    Loc loc = RBAG + tm->tid * RBAG_LEN + idx;
-    dump_term(loc);
+    dump_term(rbag_ini(tm->tid) + idx);
   }
   printf("------------------\n");
+  fflush(stdout);
 }
  
 void dump_buff() {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,8 +16,10 @@
 #include <string.h>
 #include <unistd.h>
 
+//#define OFLOW
 //#define DEBUG
 //#define MEMLOG
+//#define VOIDTEST
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
@@ -139,14 +141,14 @@ enum : u64 {
   ZERO = 0,
 
   // Threads per CPU
-  TPC = 2,
+  TPC = 4,
 
   // Number of terms *per thread* for each overflow bag. There are two of them,
   // and they (currently) borrow space from each thread's RBAG space.
-  OFLW_LEN = 1 << 14,
+  OFLW_LEN = 1 << 15,
 
   // Includes overflow and BBAG
-  RBAG_RANDO = (1 << 20) * TPC * sizeof(Pair),
+  RBAG_RANDO = (1 << 21) * TPC * sizeof(Pair),
 
   //////////////////////////
   // Choose a RBAG size here
@@ -222,7 +224,9 @@ typedef struct TM {
   u32 sgud;  // successful steal count
   u32 sbad;  // failed steal count
 
+#ifdef OFLOW
   Loc oput[2]; // next oflw bag push indices
+#endif
   
 #ifdef MEMLOG
   u32 mput;
@@ -233,11 +237,13 @@ typedef struct TM {
 #endif
 
   bool buse; // can use booty bag
-  //bool bful; // ctrl word marked full
-  bool bhld; // booty bag ctrl word is 'HELD'
+  bool bhld; // booty bag ctrl word is HELD
+
+#ifdef OFLOW
   u8   opid; // oput idx we are pushing into
   bool ouse; // can use overflow
   bool osyn; // overflow is sync'd
+#endif
 
   u64 itrs;  // interaction count
 } TM;
@@ -553,13 +559,16 @@ TM *tm_new(u64 tid) {
   tm->sid = TPC;
   tm->sgud = 0;
   tm->sbad = 0;
+  tm->bhld = true;
+  tm->buse = false;
+
+#ifdef OFLOW
   tm->oput[0] = 0;
   tm->oput[1] = 0;
   tm->opid = 0;
-  tm->bhld = true;
-  tm->buse = false;
   tm->ouse = false;
   tm->osyn = false;
+#endif
 
   return tm;
 }
@@ -642,6 +651,7 @@ static int mop_debug = 0; // memory operations
 #endif
 __attribute__((unused))
 static int bty_debug = 0; // booty bag
+__attribute__((unused))
 static int oflw_debug = 0; // overflow
 
 __attribute__((unused))
@@ -655,7 +665,7 @@ static const char* term_str(char* buf, Term term) {
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
-#ifdef MEMLOG
+#ifdef VOIDTEST
   if (got == 0) {
     fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
     mlog_exit();
@@ -671,7 +681,7 @@ Term swap(Loc loc, Term term) {
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
-#ifdef MEMLOG
+#ifdef VOIDTEST
   if (term == 0) {
     fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
     mlog_exit();
@@ -691,13 +701,11 @@ void set(Loc loc, Term term) {
   MLOG(MOP_STOR, loc, term, 0);
 }
 
-static Pair take_pair(Loc loc, bool bty) {
+static Pair take_pair(Loc loc) {
   Pair pair = *(Pair*)&BUFF[loc];
   
-  #define VOID_TEST
-
   // Debugging
-#if defined(MEMLOG) || defined(VOID_TEST)
+#if defined(MEMLOG) || defined(VOIDTEST)
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
 #endif
@@ -706,11 +714,11 @@ static Pair take_pair(Loc loc, bool bty) {
   TM *tm = tms[thread_id];
   tm->i1_tag = term_tag(neg);
   tm->i2_tag = term_tag(pos);
-  tm->itid = bty ? tm->sid : tm->tid;
+  tm->itid = tm->id; // bty ? tm->sid : tm->tid;
 #endif
   MLOG_PAIR(MOP_LOAD, loc, pair);
 
-#ifdef VOID_TEST
+#ifdef VOIDTEST
   //*(Pair*)&BUFF[loc] = (Pair)ZERO;
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
@@ -723,7 +731,7 @@ static Pair take_pair(Loc loc, bool bty) {
 }
 
 static void set_pair(Loc loc, Pair pair) {
-#if 1
+#ifdef VOIDTEST
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
   if ((neg == 0) || (pos == 0)) {
@@ -770,7 +778,7 @@ static u32 bbag_get(u32 tid) {
 }
 
 static void bbag_drop(TM *tm) {
-  #if 1 || defined(DEBUG)
+  #if defined(DEBUG)
   if (bty_debug) {
     fprintf(stderr, "%u dropping bbag! bput %u rput %u\n", //added %u dexes,
             tm->tid, tm->bput, tm->rput);
@@ -789,7 +797,7 @@ static bool bbag_recover(TM *tm) {
     tm->bhld = true;
     tm->bput = 0;
 
-    #if 1 || defined(DEBUG)
+    #if defined(DEBUG)
     if (bty_debug) {
       fprintf(stderr, "%u recovered empty stolen bbag!\n", tm->tid);
     }
@@ -808,7 +816,7 @@ static bool bbag_pickup(TM *tm) {
     tm->spop = tm->bput; // will always be BBAG_LEN
     tm->sid = tm->tid;
 
-    #if 1 || defined(DEBUG)
+    #if defined(DEBUG)
     if (bty_debug) {
       fprintf(stderr, "%d picked up our own dropped bbag!\n", tm->tid);
     }
@@ -824,7 +832,7 @@ static bool bbag_steal(TM *tm, u32 sid) {
     tm->spop = BBAG_LEN;
     tm->sid = sid;
     
-    #if 1 || defined(DEBUG)
+    #if defined(DEBUG)
     if (bty_debug) {
       fprintf(stderr, "%d stole t%u's bbag!\n", tm->tid, sid);
     }
@@ -835,7 +843,7 @@ static bool bbag_steal(TM *tm, u32 sid) {
 
 // toss the booty bag we stole from another thread and emptied
 static void bbag_toss(TM *tm) {
-  #if 1 || defined(DEBUG)
+  #if defined(DEBUG)
   if (bty_debug) {
     fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n",// removed %u dexes\n",
             tm->tid, tm->sid);//, tm->srem);
@@ -859,6 +867,7 @@ static Loc rnod_ini(u32 tid) {
   return tid * NODE_LEN;
 }
 
+#ifdef OFLOW
 static Loc oflw_offset(u32 oidx) {
   return OFLW_INI + OFLW_LEN * oidx;
 }
@@ -870,6 +879,7 @@ static Loc oflw_ini(u32 tid, u32 oidx) {
 static bool oflw_empty(TM *tm) {
   return (tm->oput[0] == 0) && (tm->oput[1] == 0);
 }  
+#endif
 
 // Allocator
 // ---------
@@ -898,6 +908,7 @@ static Loc node_alloc(TM *tm, u32 cnt) {
 }
 
 static Loc get_push_offset(TM *tm, bool force_oflw) {
+#ifdef OFLOW
   if (force_oflw && tm->ouse) {
     #if defined(DEBUG)
     if (oflw_debug) {
@@ -910,6 +921,7 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
     tm->oput[tm->opid] += 2;
     return oflw_offset(tm->opid) + oput;
   }
+#endif
 
   // Only push to booty bag if we aren't stealing
   if (tm->buse && tm->bhld && !bbag_full(tm) && (tm->sid == TPC)) {
@@ -935,7 +947,7 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
 }
 
 static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
-#if 1
+#ifdef VOIDTEST
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d rbag_push: void term\n", thread_id);
     exit_stacktrace();
@@ -950,7 +962,7 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
 
   // TODO: adjust_put_idx(tm, off);
 
-#if 1
+#ifdef OFLOW
   if (off >= OFLW_INI) {
     // pushed to overflow
     if (tm->oput[tm->opid] >= OFLW_LEN-1) {
@@ -958,7 +970,10 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
               tm->opid, tm->oput[tm->opid]);
       exit(1);
     }
-  } else if (off > BBAG_LEN) {
+  } else
+#endif
+#ifdef DEBUG
+  if (off > BBAG_LEN) {
     // pushed to RBAG
     if (tm->rput >= RPUT_MAX-1) {
       fprintf(stderr, "%u rbag space exhausted\n", tm->tid);
@@ -971,6 +986,7 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
 _Thread_local u64 noflw = 0;
 
 static Loc redex_pop_loc(TM* tm) {
+#ifdef OFLOW
   // Must check overflow bag first when sync'd
   if (tm->ouse) {
     if (tm->osyn) {
@@ -991,18 +1007,8 @@ static Loc redex_pop_loc(TM* tm) {
         return oflw_ini(tm->tid, oidx) + tm->oput[oidx];
       }
     }
-
-#if 0
-    // If the overflow put bag is full, don't allow any pops from anywhere.
-    // Overflow will empty on next sync.
-    u32 oput = tm->oput[tm->opid];
-    u32 opop = tm->oput[1-tm->opid] / 2;
-    if (oput+opop >= OFLW_LEN) {
-      //fprintf(stderr, "%u no pops overflow %u full\n", tm->tid, tm->opid);
-      return 0;
-    }
-#endif
   }
+#endif
     
   if ((tm->sid < TPC) && (tm->spop > 0)) {
     // Pop from stolen non-empty booty bag - but we could have 'stolen' our
@@ -1056,8 +1062,10 @@ void hvm_init() {
   fprintf(stderr, "RBAG_LEN = %u\n", RBAG_LEN);
   fprintf(stderr, "NODE_LEN = %u\n", NODE_LEN);
   fprintf(stderr, "BBAG_LEN = %u\n", BBAG_LEN);
+#ifdef OFLOW
   fprintf(stderr, "OFLW_INI = %u\n", OFLW_INI);
   fprintf(stderr, "OFLW_LEN = %" PRIu64 "\n", OFLW_LEN);
+#endif
   #endif
 
   signal(SIGSEGV, segv_handler);
@@ -1194,14 +1202,6 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i+1], offset);
-#if 1
-  if ((neg == 0) || (pos == 0)) {
-    fprintf(stderr, "%d expand: void term\n", thread_id);
-    exit_stacktrace();
-    //    mlog_exit();
-  }
-#endif
-
     rbag_push(tm, neg, pos, false);
   }
   return root;
@@ -1900,7 +1900,7 @@ static bool sequential_step(TM* tm) {
   if (loc == 0) {
     return false;
   }
-  Pair pair = take_pair(loc, false);
+  Pair pair = take_pair(loc);
   interact(tm, pair_neg(pair), pair_pos(pair));
   return true;
 }
@@ -1908,7 +1908,11 @@ static bool sequential_step(TM* tm) {
 // don't allow idling if our booty bag isn't held
 // because it introduces weirdness that's easier to just ignore for now
 static bool can_idle(TM *tm) {
-  return oflw_empty(tm) && rbag_empty(tm) && bbag_empty(tm) && tm->bhld;
+  return rbag_empty(tm) && bbag_empty(tm) && tm->bhld
+#ifdef OFLOW
+    && oflw_empty(tm)
+#endif
+    ;
 }
  
 static bool set_idle(bool was_busy) {
@@ -1974,7 +1978,7 @@ static bool timeout(u64 tick) {
   return false;
 }
 
-static bool lala_and_interact(TM *tm, Pair pair, bool from_bty) {
+static bool lala_and_interact(TM *tm, Pair pair) {
   if ((tm->sid < TPC) && (tm->spop == 0)) {
     // The booty bag we stole just became empty
     if (tm->sid != tm->tid) {
@@ -2022,6 +2026,7 @@ void setup_thread_for_ecore(int thread_id) {
                      (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
 }
 
+#ifdef OFLOW
 struct SIMPLE_SYNC {
   a64 requested;
   a64 arrived;
@@ -2097,7 +2102,7 @@ static bool sync_wait_departures() {
   return true;
 }
 
-#define SYNC_REQ_SIZE 1024
+#define SYNC_REQ_SIZE 4096
 
 // more booty bag 'HELD' weirdness i'm trying to bicycle around. allow sync
 // sync requests if booty bag appears non-empty, if it's not held
@@ -2112,6 +2117,7 @@ static bool request_sync(TM *tm) {
   }
   return req;
 }
+#endif // OFLOW
 
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
@@ -2130,12 +2136,14 @@ static void* thread_func(void* arg) {
 
   // Wait until after injection to turn these on
   tm->buse = true;
-  tm->ouse = true;
+  //  tm->ouse = true;
 
+#ifdef OFLOW
   // Overflow synchronization
   // TODO: Could moving these to global to reduce code in this funciton
   bool all_arrived = false;
   bool syncing = false;
+#endif
   u64 do_nothing = 0;
 
   __attribute__((unused))
@@ -2158,6 +2166,7 @@ static void* thread_func(void* arg) {
     }
 #endif
 
+#ifdef OFLOW
     if (tm->ouse) {
       if (!syncing) {
         syncing = sync_requested();
@@ -2205,26 +2214,28 @@ static void* thread_func(void* arg) {
         }
       }
     }
+#endif
 
-    // Try to recover stolen and emptied booty bag
-    if (!tm->bhld) {
-      bbag_recover(tm);
-    }
+      // Try to recover stolen and emptied booty bag
+      if (!tm->bhld) {
+        bbag_recover(tm);
+      }
 
     // much hax
+#if 0
     u32 oidx = 1u-tm->opid;
     u32 oput = tm->oput[oidx];
-    u32 spop = tm->spop;
-    bool from_bty = tm->spop > 0; // this is so bad.
+#endif
 
     Loc loc = redex_pop_loc(tm);
     if (loc) {
       last_work_tick = 0;
 
       busy = set_busy(busy);
-
-      Pair pair = take_pair(loc, from_bty);
-      if (!lala_and_interact(tm, pair, from_bty)) {
+      
+      Pair pair = take_pair(loc);
+      if (!lala_and_interact(tm, pair)) {
+#if 0
         Tag neg_tag = term_tag(pair_neg(pair));
         Tag pos_tag = term_tag(pair_pos(pair));
         if (!((neg_tag == ERA) && (pos_tag == REF))) {
@@ -2234,6 +2245,7 @@ static void* thread_func(void* arg) {
                   tag_to_str(neg_tag), tag_to_str(pos_tag),
                   (u32)from_bty, (u32)oflw);
         }
+#endif
       }
 
       if (tm->bhld && (tm->sid == TPC) && bbag_full(tm)) {
@@ -2269,10 +2281,12 @@ static void* thread_func(void* arg) {
 static void parallel_normalize() {
   atomic_store_explicit(&net.idle, TPC-1, memory_order_relaxed);
 
+#ifdef OFLOW
   atomic_store_explicit(&ss.requested, ZERO, memory_order_relaxed);
   atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
   atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
   atomic_store_explicit(&ss.generation, ZERO, memory_order_relaxed);
+#endif
 
   for (u64 i = 0; i < TPC; i++) {
     /*int rc = */pthread_create(&threads[i], NULL, thread_func, (void*)i);

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -209,167 +209,12 @@ static _Thread_local int thread_id = 0;
 // Debugging
 static char *tag_to_str(Tag tag);
 static char *bty_ctrl_str(u32 ctrl);
-void dump_term(Loc loc);
+static void dump_term(Loc loc);
 void dump_buff(TM *tm);
 
 #define TERMSTR_BUFSIZ 128
 
 static const char* term_str(char* buf, Term term);
-
-//#define MEMLOG // comment out to disable
-
-#ifdef MEMLOG
-
-// Memory operations
-#define MOP_EXCH 0x01
-#define MOP_LOAD 0x02
-#define MOP_STOR 0x03
-
-// Memory operations log
-static u32 *MEMBUFF = NULL;
-static a64 MLOG_END = 0;
-static u32 MLOG_MAX = (1U << 25) * 2 * 5; // 32Mi * (2 ops) * (1 + 2 + 2 = 5 32-bit words per op)
-
-//static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, sid, loc, t1, t2) mlog((u32)thread_id, mop, sid, loc, t1, t2)
-#else
-#define MLOG(mop, sid, loc, t1, t2)
-#endif
-
-#ifdef MEMLOG
-static void mlog_init() {
-  if (MEMBUFF == NULL) {
-    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_MAX * sizeof(u32));
-  }
-  //memset(MEMBUFF, 0, MLOG_MAX * sizeof(u32));
-  MLOG_END = 0;
-}
-
-static void mlog_free() {
-  if (MEMBUFF != NULL) {
-    free(MEMBUFF);
-    MEMBUFF = NULL;
-  }
-}
-
-// op:3, loc: 7, tid: 4, sid: 4
-static u32 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc) {
-  return (mop << 15) | ((loc & 0x7F) << 8) | ((tid & 0xF) << 4) | (sid & 0xF);
-}
-
-static u32 mlog_mop(u32 e) {
-  return e >> 15;
-}
-
-static u32 mlog_loc(u32 e) {
-  return (e >> 8) & 0x7F;
-}
-
-static u32 mlog_tid(u32 e) {
-  return (e >> 4) & 0xF;
-}
-
-static u32 mlog_sid(u64 e) {
-  return e & 0xF;
-}
-
-#if 0
-// hi 32 bits: tid: 5, mop: 2, itr: 5, term_tag: 8
-// lo 32 bits: rbag_loc
-static u64 mlog_entry(u32 tid, u32 mop, u32 itr, Term term, u64 rbag_loc) {
-  u64 hi = (tid << 15) | ((mop & 0x3) << 13) | ((itr & 0x1F) << 8) | term_tag(term);
-  return (hi << 32) | (rbag_loc & 0xFFFFFFFF);
-}
-
-static u32 mlog_entry_hi(u64 entry) {
-  return (entry >> 32) & 0xFFFFFFFF;
-}
-
-static u32 mlog_itr(u64 entry) {
-  return (mlog_entry_hi(entry) >> 8) & 0x1F;
-}
-
-static u32 mlog_term_tag(u64 entry) {
-  return mlog_entry_hi(entry) & 0xFF;
-}
-
-static u32 mlog_rbag_loc(u64 entry) {
-  return entry & 0xFFFFFFFF;
-}
-
-static u32 mlog_loc(u64 locs) {
-  return (locs >> 32) & 0xFFFFFFFF;
-}
-
-static u32 mlog_term_loc(u64 locs) {
-  return locs & 0xFFFFFFFF;
-}
-#endif
-
-static const char* mop_str(u32 mop) {
-  switch (mop) {
-  case MOP_EXCH: return "EXCH";
-  case MOP_LOAD: return "LOAD";
-  case MOP_STOR: return "STOR";
-  default: return "????";
-  }
-}
-
-static void mlog_dump(const char* fn) {
-  FILE *fp = fopen(fn, "w");
-  if (fp == NULL) {
-    perror("mlog_dump: Error opening file");
-    return;
-  }
-  u32 end = atomic_load(&MLOG_END);
-  if (end > MLOG_MAX) end = MLOG_MAX;
-  u32 ops = 0;
-  u32 i = 0;
-  for (; i + 5 <= end; ops += 2) {
-    u32 e = MEMBUFF[i++]; // entry
-    Term t1 = *(Term*)&MEMBUFF[i];
-    i += 2;
-    Term t2 = *(Term*)&MEMBUFF[i];
-    i += 2;
-    char buf1[TERMSTR_BUFSIZ];
-    char buf2[TERMSTR_BUFSIZ];
-    fprintf(fp, "%u,%s,%u,%u,%s,%s\n", mlog_tid(e), mop_str(mlog_mop(e)),
-            mlog_sid(e), mlog_loc(e), term_str(buf1, t1), term_str(buf2, t2));
-  }
-  fclose(fp);
-  fprintf(stderr, "ops: %u, idx: %u, end: %u\n", ops, i, end);
-}
-
-static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2) {
-  static bool at_end = false;
-
-  // ugly but acceptable load-test-add pattern for debug logging.
-  u32 end = atomic_load(&MLOG_END);
-  if (end + 5 < MLOG_MAX) {
-    end = atomic_fetch_add(&MLOG_END, 5UL);
-    if (end < MLOG_MAX) {
-      MEMBUFF[end] = mlog_entry(tid, mop, sid, loc);
-      end += 1;
-      *(Term*)&MEMBUFF[end] = t1;
-      end += 2;
-      *(Term*)&MEMBUFF[end] = t2;
-      return;
-    }
-  }
-  if (!at_end) {
-    fprintf(stderr, "end of MLOG reached\n");
-    at_end = true;
-  }
-}
-#endif // MEMLOG
-
-void mlog_exit() {
-#ifdef MEMLOG
-  mlog_dump("memlog.txt");
-#endif
-  exit(1);
-}
-
 
 // TM/BS operations
 void tm_reset(TM *tm) {
@@ -542,16 +387,7 @@ void set(Loc loc, Term term) {
 }
 
 static Pair take_pair(Loc loc) {
-#if 0 || defined(ATOMIC)
-  #define VOID_TEST
-  Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], VOID, __ATOMIC_RELAXED);
-#else
   Pair pair = *(Pair*)&BUFF[loc];
-  //#define VOID_TEST
-  #ifdef VOID_TEST
-  *(Pair*)&BUFF[loc] = (Pair)VOID;
-  #endif
-#endif
 
 #ifdef VOID_TEST
   if (pair == 0) {
@@ -622,39 +458,15 @@ static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
   u32 orig = expect;
   bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
                  desire, success_order, memory_order_relaxed);
-
-  if (bty_debug) {
-    if (res) {
-      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s succeeded\n",
-              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire));
-    }
-    else if (0) {
-      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s failed, it's %s\n",
-              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire),
-              bty_ctrl_str(expect));
-    }
-  }
-
   return res;
 }
 
 static void bbag_set(u32 tid, u32 val, memory_order order) {
   atomic_store_explicit(&bbs[tid]->ctrl, val, order);
-
-  if (bty_debug) {
-    fprintf(stderr, "%d set t%u's booty bag to %s\n", thread_id, tid,
-            bty_ctrl_str(val));
-  }
 }
 
 static u32 bbag_get(u32 tid) {
   u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
-
-  if (0 && bty_debug) {
-    fprintf(stderr, "%d got t%u's booty bag: %s\n", thread_id, tid,
-            bty_ctrl_str(got));
-  }
-
   return got;
 }
 
@@ -665,11 +477,6 @@ static Loc get_push_offset(TM *tm) {
       // BBAG is full, last we checked. But maybe it's empty now
       if (bbag_get(tm->tid) == EMPTY) {
         tm->bput = 0;
-
-        if (bty_debug) {
-          fprintf(stderr, "%u own booty bag is newly empty\n", tm->tid);
-        }
-
         return tm->bput;
       }        
     } else {
@@ -697,29 +504,11 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   set_pair(loc, pair_new(neg, pos));
 
   if (bty) {
-    //MLOG(MOP_STOR, tm->tid, tm->bput, pair_neg(pair), pair_pos(pair));
-    //MLOG(MOP_STOR, tm->tid, tm->bput, neg, pos);
-
-    if (1 && bty_debug) {
-      fprintf(stderr, "%u pushed to booty bag @ %u\n", tm->tid, tm->bput);
-      char buf[TERMSTR_BUFSIZ];
-      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
-      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
-      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, neg));
-      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pos));
-    }
-
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
       bbag_set(tm->tid, FULL, memory_order_release);
-
-      if (0 && bty_debug) {
-        fprintf(stderr, "%u booty bag full\n", tm->tid);
-      }
     }
   } else {
-    //MLOG(MOP_STOR, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
-
     //#ifdef DEBUG
     bool free_global = tm->rput < RBAG_LEN - BBAG_LEN - 1;
     if (!free_global) {
@@ -746,19 +535,6 @@ static Pair rbag_pop(TM* tm) {
     // If stealing from own booty bag, adjust push index as well
     if (tm->btid == tm->tid) {
       tm->bput -= 2;
-
-      #if 0
-      // Debugging
-      if (tm->bput != tm->bpop) {
-        fprintf(stderr, "bput: %u, bpop: %u\n", tm->bput, tm->bpop);
-        exit(1);
-      }
-      #endif
-    }
-
-    if (bty_debug) {
-      fprintf(stderr, "%u popping from t%u's booty bag @ %u\n", tm->tid,
-              tm->btid, tm->bpop);
     }
 
     return RBAG + tm->btid * RBAG_LEN + tm->bpop;
@@ -784,10 +560,6 @@ void hvm_init() {
 
   alloc_static_data();
 
-#ifdef MEMLOG
-  mlog_init();
-#endif
-
   #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
   fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
@@ -803,11 +575,6 @@ void hvm_free() {
     BUFF = NULL;
   }
   free_static_data();
-
-#ifdef MEMLOG
-  mlog_free();
-#endif
-
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -933,7 +700,6 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   u32 n = 1;
   for (; n + 1 < nodes_len; n += 2) {
   #endif
-    
     Loc loc = offset + n;
 
     #ifndef STORE_128
@@ -1012,8 +778,11 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
+  bool buse = tm->buse;
+  tm->buse = false;
   move(tm, var, arg);
   move(tm, ret, bod);
+  tm->buse = buse;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1631,12 +1400,6 @@ static void sync_threads() {
 static bool set_idle(bool was_busy) {
   if (was_busy) {
     u32 idle = atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
-
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u set idle, was idle = %u\n", thread_id, idle);
-    }
-#endif
   }
   return false;
 }
@@ -1644,12 +1407,6 @@ static bool set_idle(bool was_busy) {
 static bool set_busy(bool was_busy) {
   if (!was_busy) {
     u32 idle = atomic_fetch_sub_explicit(&net.idle, 1, memory_order_relaxed);
-
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u set busy, was idle = %u\n", thread_id, idle);
-    }
-#endif
   }
   return true;
 }
@@ -1668,11 +1425,6 @@ static bool try_steal(TM *tm) {
       tm->bpop = tm->bput;
       tm->btid = tm->tid;
 
-      if (0 && bty_debug) {
-        fprintf(stderr, "%u stealing own non-full booty bag, len = %u\n",
-                tm->tid, tm->bpop);
-      }
-
       return true;
     } else {
       // To steal from our own full bag, we need to take back ownership
@@ -1680,17 +1432,7 @@ static bool try_steal(TM *tm) {
         tm->bpop = tm->bput; // BBAG_LEN, always
         tm->btid = tm->tid;
 
-        if (0 && bty_debug) {
-          fprintf(stderr, "%u stealing own full booty bag, len = %u\n",
-                  tm->tid, tm->bpop);
-        }
-
         return true;
-      } else {
-        if (0 && bty_debug) {
-          fprintf(stderr, "%u failed to steal own full booty bag\n",
-                  tm->tid); //, bty_ctrl_str(state));
-        }
       }
     }
   }
@@ -1702,11 +1444,6 @@ static bool try_steal(TM *tm) {
     tm->bpop = BBAG_LEN;
     tm->btid = vic;
     tm->sgud += 1;
-
-    if (0 && bty_debug) {
-      fprintf(stderr, "%u stealing t%u's booty bag, \n", tm->tid, tm->btid);
-    }
-
     return true;
   }
 
@@ -1753,44 +1490,20 @@ static void* thread_func(void* arg) {
       //bbag_maybe_empty(tm, prev_bpop);
 
       if (bty) {
-        //MLOG(MOP_LOAD, tm->btid, tm->bpop, pair_neg(pair), pair_pos(pair));
-
-        if (1 && bty_debug) {
-          char buf[TERMSTR_BUFSIZ];
-          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
-          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
-        }
-
         if (tm->bpop == 0) {
           if (tm->btid != tm->tid) {
             // Mark stolen booty bag empty
             bbag_set(tm->btid, EMPTY, memory_order_relaxed);
-          
-            if (0 && bty_debug) {
-              fprintf(stderr, "%u finished popping from t%u's booty bag\n",
-                      tm->tid, tm->btid);
-            }
-          }
-          else {
-            if (0 && bty_debug) {
-              fprintf(stderr, "%u finished popping from own booty bag\n", tm->tid);
-            }
           }
         }
-      } else {
-        //MLOG(MOP_LOAD, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
       }
-
-      if (pair != 0) {
-        interact(tm, pair_neg(pair), pair_pos(pair));
-      }
+      interact(tm, pair_neg(pair), pair_pos(pair));
     } else {
       busy = set_idle(busy);
 
       if (try_steal(tm)) continue;
 
       sched_yield();
-      //usleep(1);
 
       if (check_timeout(tick)) break;
     }
@@ -1803,17 +1516,6 @@ static void* thread_func(void* arg) {
     fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, bpop: %u, steals: %u good %u bad\n",
             tm->tid, tm->itrs, tm->rput, tm->bput, tm->bpop, tm->sgud, tm->sbad);
   }
-
-  //if (thd_debug) {
-  //  fprintf(stderr, "%u before sync...\n", tm->tid);
-  //}
-
-  // sync_threads();
-
-  //if (thd_debug) {
-  //  fprintf(stderr, "%u after sync done\n", tm->tid);
-  //}
-
   return NULL;
 }
 
@@ -1852,9 +1554,6 @@ Term normalize(Term term) {
 }
 
 void handle_failure() {
-#ifdef MEMLOG
-  mlog_dump("memlog.txt");
-#endif
 }
 
 // Debugging
@@ -1907,7 +1606,7 @@ static char *bty_ctrl_str(u32 ctrl) {
   }
 }
 
-void dump_term(Loc loc) {
+static void dump_term(Loc loc) {
   Term term = get(loc);
   printf("%06X %03X %03X %s\n", loc, term_loc(term), term_lab(term),
       tag_to_str(term_tag(term)));

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 //#define DEBUG
+#define MEMLOG
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
@@ -204,24 +205,27 @@ typedef struct TM {
   u32 tid;   // thread id
   Loc nput;  // next node allocation attempt index
   Loc rput;  // next rbag push index
-  Loc bput;  // owned) bbag push index
+  Loc bput;  // (owned) bbag push index
   u32 sid;   // tid from which bbag was stolen
   Loc spop;  // stolen bbag pop index + 2
+
   u32 sgud;  // successful steal count
   u32 sbad;  // failed steal count
 
-  // debugging
+  // memlog
   u32 mput;
   u32 itid;
-  u32 i1_tag;
-  u32 i2_tag;
+  uint8_t i1_tag;
+  uint8_t i2_tag;
+  bool mwrp; // memlog wrapped
+
+  bool buse; // use booty bag
+  bool bful; // ctrl word marked full
 
   u64 itrs;  // interaction count
-  bool buse; // use booty bag
-  bool bful; 
 } TM;
 
-//static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
+static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
 
 // Booty bag control word values
 enum : u32 {
@@ -255,25 +259,31 @@ static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
-#define MEMLOG // comment out to disable
-
 #ifdef MEMLOG
 // Memory operations log
 static u64 *MEMBUFF = NULL;
 enum : u32 {
-  MLOG_SIZ = (1U << 26) * sizeof(u64) * 3,
+  MLOG_SIZ = 4096 * TPC * sizeof(u64) * 3,
   MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
 };
 
 //static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0, false)
-#define MLOG_PAIR(mop, loc, pair, lvl)  mlog((u32)thread_id, mop, loc, pair_neg(pair), pair_pos(pair), lvl, true)
-#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl, false)
+#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
+#define MLOG_PAIR(mop, loc, pair)       mlog_pair((u32)thread_id, mop, loc, pair)
+#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
 #else
 #define MLOG(mop, loc, t1, t2)
-#define MLOG_PAIR(mop, loc, pair, lvl)
+#define MLOG_PAIR(mop, loc, pair)
 #define MLOG_LVL(mop, loc, lvl, t1, t2)
 #endif
+
+static u32 u64_hi(u64 e) {
+  return e >> 32;
+}
+
+static u32 u64_lo(u64 e) {
+  return e & 0xFFFFFFFF;
+}
 
 // Memory operations
 #define MOP_EXCH 0x01
@@ -314,55 +324,79 @@ static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
   return hi << 32 | loc;
 }
 
-static u32 mlog_hi(u64 e) {
-  return e >> 32;
-}
-
-static u32 mlog_lo(u64 e) {
-  return e & 0xFFFFFFFF;
-}
-
 static u32 mlog_i1_tag(u64 e) {
-  return (mlog_hi(e) >> 27);
+  return (u64_hi(e) >> 27);
 }
 
 static u32 mlog_i2_tag(u64 e) {
-  return (mlog_hi(e) >> 23) & 0xF;
+  return (u64_hi(e) >> 23) & 0xF;
 }
 
 static u32 mlog_lvl(u64 e) {
-  return (mlog_hi(e) >> 18) & 0x1F;
+  return (u64_hi(e) >> 18) & 0x1F;
 }
 
 static u32 mlog_mop(u64 e) {
-  return (mlog_hi(e) >> 16) & 0x3;
+  return (u64_hi(e) >> 16) & 0x3;
 }
 
 static u32 mlog_t1_tag(u64 e) {
-  return (mlog_hi(e) >> 12) & 0xF;
+  return (u64_hi(e) >> 12) & 0xF;
 }
 
 static u32 mlog_t2_tag(u64 e) {
-  return (mlog_hi(e) >> 8) & 0xF;
+  return (u64_hi(e) >> 8) & 0xF;
 }
 
 static u32 mlog_tid(u64 e) {
-  return (mlog_hi(e) >> 4) & 0xF;
+  return (u64_hi(e) >> 4) & 0xF;
 }
 
+__attribute__((unused))
 static u32 mlog_sid(u64 e) {
-  return mlog_hi(e) & 0xF;
+  return u64_hi(e) & 0xF;
 }
 
 static u32 mlog_loc(u64 e) {
-  return mlog_lo(e);
+  return u64_lo(e);
 }
 
-static void mlog_dump_term(FILE* fp, u64 cnt, u64 e, u32 tag, Loc loc, u32 loc_offset) {
-  fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%u\n", cnt, mlog_tid(e),
+static void mlog_dump_term(FILE* fp, u64 cntr, u64 e, u32 tag, Loc loc, u32 loc_offset) {
+  fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%u\n", cntr, mlog_tid(e),
           tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
           mop_str(mlog_mop(e)), mlog_lvl(e),
           tag_to_str(tag), loc, mlog_loc(e) + loc_offset);
+}
+
+static void mlog_dump_entry(FILE *fp, u64 cntr, u64 e, u64 locs) {
+  u32 mop = mlog_mop(e);
+  Loc t1_loc = u64_hi(locs);
+  Loc t2_loc = u64_lo(locs);
+  if ((mop == MOP_LOAD) || (mop == MOP_STOR)) {
+    mlog_dump_term(fp, cntr, e, mlog_t1_tag(e), t1_loc, 0);   // T1 
+    /*
+    if ((mlog_t2_tag(e) != 0) || (t2_loc != 0)) {
+      mlog_dump_term(fp, cntr, e, mlog_t2_tag(e), t2_loc, 1); // T2
+    }
+    */
+  } else {
+    fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%s,%u,%u\n", cntr, mlog_tid(e),
+            tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
+            mop_str(mop), mlog_lvl(e), tag_to_str(mlog_t1_tag(e)), t1_loc, 
+            tag_to_str(mlog_t2_tag(e)), t2_loc, mlog_loc(e));
+  }
+}
+
+static u32 mlog_dump_range(FILE *fp, u32 ini, u32 off, u32 end, u32 *nlog) {
+  for (; (off + 2) < end; off += 3) {
+    u32 pos  = ini + off;
+    u64 cntr = MEMBUFF[pos]; 
+    u64 e    = MEMBUFF[pos+1]; // entry
+    u64 locs = MEMBUFF[pos+2];
+    mlog_dump_entry(fp, cntr, e, locs);
+    if (nlog) (*nlog)++;
+  }
+  return off;
 }
 
 static void mlog_dump(const char* fn) {
@@ -372,59 +406,97 @@ static void mlog_dump(const char* fn) {
     return;
   }
 
-  u32 ops = 0;
-  for (u64 t = 0; t < TPC; t++) {
-    TM *tm = tms[t];
-    for (u32 i = 0; i < tm->mput; i += 3) {
-      u32 pos = t * MLOG_LEN + i;
-      u64 cnt =  MEMBUFF[pos]; 
-      u64 e =    MEMBUFF[pos+1]; // entry
-      u64 locs = MEMBUFF[pos+2]; // locs
-      u32 mop = mlog_mop(e);
-      if ((mop == MOP_LOAD) || (mop == MOP_STOR)) {
-        // T1 
-        Loc t1_loc = mlog_hi(locs);
-        mlog_dump_term(fp, cnt, e, mlog_t1_tag(e), t1_loc, 0);
-        Loc t2_loc = mlog_lo(locs);
-        if ((mlog_t2_tag(e) != 0) || (t2_loc != 0)) {
-          // T2
-          mlog_dump_term(fp, cnt, e, mlog_t2_tag(e), t2_loc, 1);
+  for (u32 tid = 0; tid < TPC; tid++) {
+    TM *tm = tms[tid];
+    u32 ini = tid * MLOG_LEN;
+    u32 off = tm->mwrp ? tm->mput : 0;
+    u32 end = tm->mwrp ? MLOG_LEN : tm->mput;
+    u32 nlog = 0;
+
+    off = mlog_dump_range(fp, ini, off, end, &nlog);
+    if (tm->mwrp) {
+      if (off < end) {
+        u64 words[3];
+        u32 idx = 0;
+        for (; off < end; off++, idx++) {
+          if (idx > 2) {
+            fprintf(stderr, "idx %u!\n", idx);
+            exit(1);
+          }
+          words[idx] = MEMBUFF[ini + off];
         }
+        off = 0;
+        end = tm->mput;
+        for (; idx < 3; idx++, off++) {
+          words[idx] = MEMBUFF[ini + off];
+        }
+        mlog_dump_entry(fp, words[0], words[1], words[2]);
+        nlog += 1;
       } else {
-        fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%s,%u,%u\n", cnt, mlog_tid(e),
-                tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
-                /*mlog_sid(e),*/ mop_str(mlog_mop(e)), mlog_lvl(e),
-                tag_to_str(mlog_t1_tag(e)), mlog_hi(locs),
-                tag_to_str(mlog_t2_tag(e)), mlog_lo(locs), mlog_loc(e));
+        off = 0;
       }
+      mlog_dump_range(fp, ini, off, end, &nlog);
+      //fprintf(stderr, "%u dumped %u wrapped entries, off %u end %u\n",
+      //tid, wrapped, off, end);
     }
+    //fprintf(stderr, "%u dumped %u %s\n", tid, nlog,
+    //tm->mwrp ? "wrapped" : "no wrap");
   }
   fclose(fp);
 }
 
-static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl, bool force_t2) {
-  static bool at_end = false;
-
-  TM *tm = tms[tid];
-  if (tm->mput + 3 < MLOG_LEN) {
-    u32 pos = tid * MLOG_LEN + tm->mput;
-
-    MEMBUFF[pos] = read_cntvct();
-    MEMBUFF[pos+1] = mlog_entry(tid, mop, tm->itid, loc, lvl, tm->i1_tag,
-                                tm->i2_tag, term_tag(t1), term_tag(t2));
-    MEMBUFF[pos+2] = (u64)term_loc(t1) << 32 | term_loc(t2);
-
-    tm->mput += 3;
-  } else if (!at_end) {
-    fprintf(stderr, "%u end of MLOG reached\n", tid);
-    at_end = true;
+static u64 mlog_get_word(u32 idx, TM *tm, u32 mop, Loc loc, u32 lvl, Term t1, Term t2) {
+  switch (idx) {
+  case 0: return read_cntvct();
+  case 1: return mlog_entry(tm->tid, mop, tm->itid, loc, lvl, tm->i1_tag,
+                            tm->i2_tag, term_tag(t1), term_tag(t2));
+  case 2: return (u64)term_loc(t1) << 32 | term_loc(t2); // TODO new_u64()
+  default:
+    break;
   }
+  fprintf(stderr, "bad idx %u\n", idx);
+  exit(1);
+}
+
+static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
+  TM *tm = tms[tid];
+  for (u32 i = 0; i < 3; i++, tm->mput++) {
+    if (tm->mput == MLOG_LEN) {
+      tm->mput = 0;
+      tm->mwrp = true;
+    }
+    u32 pos = tid * MLOG_LEN + tm->mput;
+    MEMBUFF[pos] = mlog_get_word(i, tm, mop, loc, lvl, t1, t2);
+  }
+}
+
+static void mlog_pair(u32 tid, u32 mop, Loc loc, Pair pair) {
+  mlog(tid, mop, loc, pair_neg(pair), 0, 0);
+  mlog(tid, mop, loc, pair_pos(pair), 0, 0);
 }
 
 #endif // MEMLOG
 
+void cancel_threads() {
+  for (int i = 0; i < TPC; i++) {
+    if (i != thread_id) {
+      pthread_cancel(threads[i]);
+    }
+  }
+  for (int i = 0; i < TPC; i++) {
+    if (i != thread_id) {
+      thread_join(threads[i], NULL);
+    }
+  }
+}
+
 void mlog_exit() {
 #ifdef MEMLOG
+  fprintf(stderr, "%d mlog_exit() cancelling threads...", thread_id);
+  cancel_threads();
+  fprintf(stderr, "done\n");
+  TM *tm = tms[0];
+  fprintf(stderr, "%d mput %u of LEN %u\n", thread_id, tm->mput, MLOG_LEN);
   mlog_dump("memlog.txt");
 #endif
   exit(1);
@@ -437,6 +509,7 @@ void tm_reset(TM *tm) {
   tm->itrs = 0;
 
   tm->mput = 0;
+  tm->mwrp = false;
 }
 
 TM *tm_new(u64 tid) {
@@ -528,10 +601,13 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
+#ifdef DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
 static int bty_debug = 1; // booty bag
+#endif
 
+__attribute__((unused))
 static const char* term_str(char* buf, Term term) {
   sprintf(buf, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
           (u32)term_lab(term), (u32)term_loc(term));
@@ -542,6 +618,12 @@ static const char* term_str(char* buf, Term term) {
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
+#if 1
+  if (got == 0) {
+    fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
+    mlog_exit();
+  }
+#endif
   return got;
 }
 
@@ -552,6 +634,10 @@ Term swap(Loc loc, Term term) {
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
+  if (term == 0) {
+    fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
+    mlog_exit();
+  }
   return term;
 }
 
@@ -569,25 +655,27 @@ void set(Loc loc, Term term) {
 static Pair take_pair(Loc loc, bool bty) {
   Pair pair = *(Pair*)&BUFF[loc];
   
+#define VOID_TEST
+
   // Debugging
-#if defined(MEMLOG)
+#if defined(MEMLOG) || defined(VOID_TEST)
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
+#endif
 
+#if defined(MEMLOG)
   TM *tm = tms[thread_id];
   tm->i1_tag = term_tag(neg);
   tm->i2_tag = term_tag(pos);
   tm->itid = bty ? tm->sid : tm->tid;
-
-  MLOG_PAIR(MOP_LOAD, loc, pair, 0);
 #endif
+  MLOG_PAIR(MOP_LOAD, loc, pair);
 
-//#define VOID_TEST
 #ifdef VOID_TEST
-  *(Pair*)&BUFF[loc] = (Pair)VOID;
-  if (pair == 0) {
-    fprintf(stderr, "%d VOID pair taken\n", thread_id);
-    exit(1);
+  //*(Pair*)&BUFF[loc] = (Pair)VOID;
+  if ((neg == 0) || (pos == 0)) {
+    fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
+    mlog_exit();
   }
 #endif
   
@@ -596,7 +684,7 @@ static Pair take_pair(Loc loc, bool bty) {
 
 static void set_pair(Loc loc, Pair pair) {
   *((Pair*)&BUFF[loc]) = pair;
-  MLOG_PAIR(MOP_STOR, loc, pair, 0);
+  MLOG_PAIR(MOP_STOR, loc, pair);
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -635,7 +723,6 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   if (tm->nput + cnt >= NODE_LEN) {
     fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
             tm->tid, tm->nput, cnt, NODE_LEN);
-    //fflush(stderr);
     exit(1);
   }
 
@@ -732,8 +819,6 @@ void hvm_init() {
 
   alloc_static_data();
 
-  signal(SIGSEGV, segv_handler);
-
   #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
   fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
@@ -741,6 +826,12 @@ void hvm_init() {
   fprintf(stderr, "RBAG_LEN  = %u\n", RBAG_LEN);
   fprintf(stderr, "NODE_LEN  = %u\n", NODE_LEN);
   #endif
+
+  //signal(SIGSEGV, segv_handler);
+
+#ifdef MEMLOG
+  mlog_init();
+#endif
 }
 
 void hvm_free() {
@@ -749,6 +840,10 @@ void hvm_free() {
     BUFF = NULL;
   }
   free_static_data();
+
+#ifdef MEMLOG
+  mlog_free();
+#endif
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -800,6 +895,7 @@ u32 upr_bnd(Loc *locs, u32 cnt, Loc tgt) {
   return lft;
 }
 
+__attribute__((unused))
 static u32 dup_bod(Term *src, Term *dst, u32 nsrc) {
   Term lam = src[0];
   if (term_tag(lam) != LAM) return 0;
@@ -1764,6 +1860,8 @@ static void* thread_func(void* arg) {
   u32  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
+    pthread_testcancel();
+
     tick += 1;
 
     bool from_bty = tm->spop > 0; // haxor
@@ -1819,7 +1917,7 @@ static void parallel_normalize() {
   atomic_store_explicit(&net.idle, TPC - 1, memory_order_relaxed);
 
   for (u64 i = 0; i < TPC; i++) {
-    int rc = thread_create(&threads[i], NULL, thread_func, (void*)i);
+    /*int rc = */thread_create(&threads[i], NULL, thread_func, (void*)i);
   }
 
   for (u64 i = 0; i < TPC; i++) {
@@ -1847,7 +1945,9 @@ Term normalize(Term term) {
     parallel_normalize();
   }
 
-  //  mlog_dump("memlog.good");
+#ifdef MEMLOG
+  mlog_dump("memlog.txt");
+#endif
 
   return get(0);
 }
@@ -1896,6 +1996,7 @@ static char *tag_to_str(Tag tag) {
   }
 }
 
+__attribute__((unused))
 static char *bty_ctrl_str(u32 ctrl) {
   switch (ctrl) {
   case EMPTY:  return "EMPTY";

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -54,14 +54,14 @@ int thread_join(pthread_t thread, void **retval) {
 #define OP_MUL 0x02
 #define OP_DIV 0x03
 #define OP_MOD 0x04
-#define OP_EQ 0x05
-#define OP_NE 0x06
-#define OP_LT 0x07
-#define OP_GT 0x08
+#define OP_EQ  0x05
+#define OP_NE  0x06
+#define OP_LT  0x07
+#define OP_GT  0x08
 #define OP_LTE 0x09
 #define OP_GTE 0x0A
 #define OP_AND 0x0B
-#define OP_OR 0x0C
+#define OP_OR  0x0C
 #define OP_XOR 0x0D
 #define OP_LSH 0x0E
 #define OP_RSH 0x0F
@@ -225,33 +225,93 @@ void dump_buff(TM *tm);
 
 #define TERMSTR_BUFSIZ 128
 
+static Term pair_pos(Pair pair);
+static Term pair_neg(Pair pair);
 static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
+Loc term_loc(Term term);
 
 #define MEMLOG // comment out to disable
+//#define LOCLOG
+
+#if defined(MEMLOG) && defined(LOCLOG)
+#error "define MEMLOG -or- LOCLOG not both"
+#endif
 
 #ifdef MEMLOG
+
+// Memory operations log
+static u64 *MEMBUFF = NULL;
+enum : u32 {
+  MLOG_SIZ = (1U << 26) * sizeof(u64) * 3,
+  MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
+};
+
+//static _Thread_local u64 rbag_loc = 0;
+#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
+#define MLOG_PAIR(mop, loc, pair)       mlog((u32)thread_id, mop, loc, pair_neg(pair), pair_pos(pair), 0)
+#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
+#else
+#define MLOG(mop, loc, t1, t2)
+#define MLOG_PAIR(mop, loc, pair)
+#define MLOG_LVL(mop, loc, lvl, t1, t2)
+#endif
 
 // Memory operations
 #define MOP_EXCH 0x01
 #define MOP_LOAD 0x02
 #define MOP_STOR 0x03
 
-// Memory operations log
-static u64 *MEMBUFF = NULL;
-//static a64 MLOG_END = 0;
-enum : u32 {
-  MLOG_SIZ = (1U << 26) * sizeof(u64),
-  MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
-};
+static const char* mop_str(u32 mop) {
+  switch (mop) {
+  case MOP_EXCH: return "EXCH";
+  case MOP_LOAD: return "LOAD";
+  case MOP_STOR: return "STOR";
+  default: return "????";
+  }
+}
 
-//static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
-#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
-#else
-#define MLOG(mop, loc, t1, t2)
-#define MLOG_LVL(mop, loc, lvl, t1, t2)
+static bool is_log_loc(Loc loc) {
+  return (loc == 80) || (loc == 81); //|| (loc == 111)) {
+}
+
+static const char* other_term_str(char* buf, Term term) {
+  char term_buf[128];
+  if (term != 0) {
+    sprintf(buf, "other: %s", term_str(term_buf, term));
+    return buf;
+  }
+  return "";
+}
+
+static void log_term_loc_other(u32 mop, Term term, Loc loc, Term other) {
+  Loc tloc = term_loc(term);
+  if (is_log_loc(tloc) || is_log_loc(loc)) {
+    TM *tm = tms[thread_id];
+    char buf[128];
+    char other_buf[128];
+    fprintf(stderr, "%d %s%s %s %s %s @ %u %s\n", thread_id,
+            tag_to_str(tm->i1_tag), tag_to_str(tm->i2_tag),
+            (loc < RBAG) ? "RNOD" : "RBAG",
+            mop_str(mop), term_str(buf, term), loc,
+            other_term_str(other_buf, other));
+  }
+}
+
+static void log_term_loc(u32 mop, Term term, Loc loc) {
+#ifdef LOC_LOG
+  log_term_loc_other(mop, term, loc, 0);
 #endif
+}
+
+static void log_pair_loc(u32 mop, Pair pair, Loc loc) {
+#ifdef LOC_LOG
+  Term neg = pair_neg(pair);
+  Term pos = pair_pos(pair);
+  log_term_loc_other(mop, neg, loc, pos);
+  log_term_loc_other(mop, pos, loc+1, neg);
+#endif
+}
 
 #ifdef MEMLOG
 static void mlog_init() {
@@ -280,6 +340,10 @@ static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
 
 static u32 mlog_hi(u64 e) {
   return e >> 32;
+}
+
+static u32 mlog_lo(u64 e) {
+  return e & 0xFFFFFFFF;
 }
 
 static u32 mlog_i1_tag(u64 e) {
@@ -315,16 +379,14 @@ static u32 mlog_sid(u64 e) {
 }
 
 static u32 mlog_loc(u64 e) {
-  return e & 0xFFFFFFFF;
+  return mlog_lo(e);
 }
 
-static const char* mop_str(u32 mop) {
-  switch (mop) {
-  case MOP_EXCH: return "EXCH";
-  case MOP_LOAD: return "LOAD";
-  case MOP_STOR: return "STOR";
-  default: return "????";
-  }
+static void mlog_dump_term(FILE* fp, u64 cnt, u64 e, u32 tag, Loc loc, u32 loc_offset) {
+  fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%u\n", cnt, mlog_tid(e),
+          tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
+          mop_str(mlog_mop(e)), mlog_lvl(e),
+          tag_to_str(tag), loc, mlog_loc(e) + loc_offset);
 }
 
 static void mlog_dump(const char* fn) {
@@ -337,26 +399,31 @@ static void mlog_dump(const char* fn) {
   u32 ops = 0;
   for (u64 t = 0; t < TPC; t++) {
     TM *tm = tms[t];
-    for (u32 i = 0; i < tm->mput; i += 2) {
+    for (u32 i = 0; i < tm->mput; i += 3) {
       u32 pos = t * MLOG_LEN + i;
-      u64 cnt = MEMBUFF[pos]; 
-      u64 e = MEMBUFF[pos+1]; // entry
-
-      /*
-      Term t1 = *(Term*)&MEMBUFF[i+1];
-      Term t2 = *(Term*)&MEMBUFF[i];
-      char buf1[TERMSTR_BUFSIZ];
-      char buf2[TERMSTR_BUFSIZ];
-      */
-      fprintf(fp, "%" PRIu64 ",%u,%s%s,%u,%s,%u,%s,%s,%u\n", cnt, mlog_tid(e),
-              tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
-              mlog_sid(e), mop_str(mlog_mop(e)), mlog_lvl(e),
-              tag_to_str(mlog_t1_tag(e)), tag_to_str(mlog_t2_tag(e)),
-              mlog_loc(e));
+      u64 cnt =  MEMBUFF[pos]; 
+      u64 e =    MEMBUFF[pos+1]; // entry
+      u64 locs = MEMBUFF[pos+2]; // locs
+      u32 mop = mlog_mop(e);
+      if ((mop == MOP_LOAD) || (mop == MOP_STOR)) {
+        // T1 
+        Loc t1_loc = mlog_hi(locs);
+        mlog_dump_term(fp, cnt, e, mlog_t1_tag(e), t1_loc, 0);
+        Loc t2_loc = mlog_lo(locs);
+        if ((mlog_t2_tag(e) != 0) || (t2_loc != 0)) {
+          // T2
+          mlog_dump_term(fp, cnt, e, mlog_t2_tag(e), t2_loc, 1);
+        }
+      } else {
+        fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%s,%u,%u\n", cnt, mlog_tid(e),
+                tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
+                /*mlog_sid(e),*/ mop_str(mlog_mop(e)), mlog_lvl(e),
+                tag_to_str(mlog_t1_tag(e)), mlog_hi(locs),
+                tag_to_str(mlog_t2_tag(e)), mlog_lo(locs), mlog_loc(e));
+      }
     }
   }
   fclose(fp);
-  //  fprintf(stderr, "ops: %u\n", ops);
 }
 
 #ifdef __APPLE__
@@ -377,20 +444,18 @@ static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
   static bool at_end = false;
 
   TM *tm = tms[tid];
-  if (tm->mput + 2 < MLOG_LEN) {
+  if (tm->mput + 3 < MLOG_LEN) {
     u32 pos = tid * MLOG_LEN + tm->mput;
 
     MEMBUFF[pos] = read_cntvct();
     MEMBUFF[pos+1] = mlog_entry(tid, mop, tm->itid, loc, lvl, tm->i1_tag,
                                 tm->i2_tag, term_tag(t1), term_tag(t2));
 
-    /*
-    *(Term*)&MEMBUFF[end] = t1;
-    end += 2;
-    *(Term*)&MEMBUFF[end] = t2;
-    */
+#if 1
+    MEMBUFF[pos+2] = (u64)term_loc(t1) << 32 | term_loc(t2);
+#endif
 
-    tm->mput += 2;
+    tm->mput += 3;
   } else if (!at_end) {
     fprintf(stderr, "%u end of MLOG reached\n", tid);
     at_end = true;
@@ -528,9 +593,11 @@ static const char* term_str(char* buf, Term term) {
 
 // Memory operations
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
-  Term res = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-  MLOG_LVL(MOP_EXCH, loc, lvl, res, term);
-  return res;
+  Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
+  MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
+  log_term_loc(MOP_STOR, term, loc);
+  log_term_loc(MOP_LOAD, got, loc);
+  return got;
 }
 
 Term swap(Loc loc, Term term) {
@@ -540,28 +607,46 @@ Term swap(Loc loc, Term term) {
 Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
   MLOG(MOP_LOAD, loc, term, 0);
+  log_term_loc(MOP_LOAD, term, loc);
   return term;
 }
 
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
+  log_term_loc(MOP_LOAD, term, loc);
   return term;
 }
 
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG(MOP_STOR, loc, term, 0);
+  log_term_loc(MOP_STOR, term, loc);
 }
 
-static Pair take_pair(Loc loc) {
+static Pair take_pair(Loc loc, bool bty) {
   Pair pair = *(Pair*)&BUFF[loc];
-  //#define VOID_TEST
-#ifdef VOID_TEST
-  *(Pair*)&BUFF[loc] = (Pair)VOID;
+  
+  // Debugging
+#if defined(MEMLOG) || defined(LOCLOG)
+  Term neg = pair_neg(pair);
+  Term pos = pair_pos(pair);
+
+  TM *tm = tms[thread_id];
+  tm->i1_tag = term_tag(neg);
+  tm->i2_tag = term_tag(pos);
+  tm->itid = bty ? tm->btid : tm->tid;
+
+  MLOG(MOP_LOAD, loc, neg, pos);
+
+#ifdef LOCLOC
+  log_pair_loc(MOP_LOAD, pair, loc);
+#endif
 #endif
 
+//#define VOID_TEST
 #ifdef VOID_TEST
+  *(Pair*)&BUFF[loc] = (Pair)VOID;
   if (pair == 0) {
     fprintf(stderr, "%d VOID term taken\n", thread_id);
     exit(1);
@@ -571,8 +656,14 @@ static Pair take_pair(Loc loc) {
   return pair;
 }
 
+static void atomic_set_pair(Loc loc, Pair pair) {
+  __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
+  MLOG_PAIR(MOP_STOR, loc, pair);
+}
+
 static void set_pair(Loc loc, Pair pair) {
   *((Pair*)&BUFF[loc]) = pair;
+  MLOG_PAIR(MOP_STOR, loc, pair);
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -640,7 +731,10 @@ static Loc rbag_push(TM *tm, Term neg, Term pos) {
   bool bty = off < BBAG_LEN;
   Loc loc = RBAG + tm->tid * RBAG_LEN + off;
 
-  set_pair(loc, pair_new(neg, pos));
+  Pair pair = pair_new(neg, pos);
+  set_pair(loc, pair);
+
+  log_pair_loc(MOP_STOR, pair, loc);
 
   if (bty) {
     tm->bput += 2;
@@ -826,17 +920,25 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   Term root = term_offset_loc(nodes[0], offset);
 
-  // No redexes reference these nodes yet; safe to add without atomics.
   u32 n = 1;
   for (; n + 1 < nodes_len; n += 2) {
-    Loc loc = offset + n;
     // 128-bit load & store
-    Pair pair = *(Pair*)&nodes[n];
-    *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
-                                  term_offset_loc(pair_pos(pair), offset));
+    Pair orig = *(Pair*)&nodes[n];
+    Term neg = term_offset_loc(pair_neg(orig), offset);
+    Term pos = term_offset_loc(pair_pos(orig), offset);
+    Loc loc = offset + n;
+    // What if we add these without atomics, then release on first
+    // rbag_push, and acquire on take_pair?
+    //*(Pair*)&BUFF[loc] = pair_new(neg, pos);
+    atomic_set_pair(loc, pair_new(neg, pos));
+    MLOG_LVL(MOP_STOR, loc, def_idx, neg, pos);
+    log_term_loc(MOP_STOR, neg, loc);
+    log_term_loc(MOP_STOR, pos, loc+1);
   }
   if (n < nodes_len) {
-    BUFF[offset + n] = term_offset_loc(nodes[n], offset);
+    Term term = term_offset_loc(nodes[n], offset);
+    BUFF[offset + n] = term;
+    MLOG_LVL(MOP_STOR, offset+n, def_idx, term, 0);
   }
 
   for (u32 i = 0; i < rbag_len; i += 2) {
@@ -1539,7 +1641,7 @@ static inline bool sequential_step(TM* tm) {
     return false;
   }
 
-  Pair pair = take_pair(loc);
+  Pair pair = take_pair(loc, false);
   interact(tm, pair_neg(pair), pair_pos(pair));
   return true;
 }
@@ -1623,12 +1725,7 @@ static void* thread_func(void* arg) {
     if (loc) {
       busy = set_busy(busy);
 
-      Pair pair = take_pair(loc);
-
-      // Debugging
-      tm->i1_tag = term_tag(pair_neg(pair));
-      tm->i2_tag = term_tag(pair_pos(pair));
-      tm->itid = bty ? tm->btid : tm->tid;
+      Pair pair = take_pair(loc, bty);
 
       if (bty && (tm->bpop == 0) && (tm->btid != tm->tid)) {
         // Mark stolen booty bag empty

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -17,13 +17,22 @@
 #include <unistd.h>
 
 //#define DEBUG
-//#define MEMLOG
+#define MEMLOG
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
 int get_num_threads() {
   long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
   return (nprocs <= 1) ? 1 : 1 << (int)log2(nprocs);
+}
+
+void exit_stacktrace() {
+  void *array[10];
+  size_t size;
+  
+  size = backtrace(array, 10);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
 }
 
 void segv_handler(int sig) {
@@ -130,38 +139,36 @@ enum : u64 {
   ZERO = 0,
 
   // Threads per CPU
-  TPC = 4,
+  TPC = 2,
 
   // Number of terms *per thread* for each overflow bag. There are two of them,
-  // and they (currently) steal space from each thread's RBAG space.
-  // NB: These numbers are a bit aggresive. Overflow of overflow could happen.
-  OFLW_LEN = 1 << 18,
-  OFLW_SYNC = 1024,
+  // and they (currently) borrow space from each thread's RBAG space.
+  OFLW_LEN = 1 << 14,
 
-  // Various redex bag sizes within the heap to choose from. The remaining
-  // percentage is used for node storage. Assumes 10 threads.
-  RBAG_TEST = (1 << 23) * TPC * sizeof(Pair),
+  // Includes overflow and BBAG
+  RBAG_RANDO = (1 << 20) * TPC * sizeof(Pair),
 
   //////////////////////////
   // Choose a RBAG size here
   //////////////////////////
-  RBAG_SIZE = RBAG_TEST,
+  RBAG_SIZE = RBAG_RANDO,
 };
 
 enum : u32 {
-  // Final calculated RBAG index
-  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(Term)) & ~7U, // CACH_U64 - 1
+  // Must of these must be 16-byte aligned (even).
 
-  // Calculate RBAG_LEN and NODE_LEN: number of u64 elements *per thread*
-  // RBAG_LEN MUST be 16-byte aligned. 64-byte alignment might be preferable
-  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(Term))) & ~7U, // CACH_U64 - 1
+  // Final calculated RBAG index
+  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(Term)) & ~1ULL,
+
+  // Calculate RBAG_LEN and NODE_LEN: number of terms *per thread*
+  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(Term))) & ~1ULL,
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(Term)),
 
-  // Booty-bag length in u64 elements
-  BBAG_LEN = 96,
+  // Booty-bag length.
+  BBAG_LEN = 16,
 
   // Offset in RBAG of overflow bags
-  OFLW_INI = RBAG_LEN - (OFLW_LEN * 2),
+  OFLW_INI = (RBAG_LEN - (OFLW_LEN * 2)) & ~1ULL,
 
   // Max terms allowed in RBAG, taking into account booty bag and overflow
   RPUT_MAX = OFLW_INI - BBAG_LEN
@@ -230,7 +237,6 @@ typedef struct TM {
   u8   opid; // oput idx we are pushing into
   bool ouse; // can use overflow
   bool osyn; // overflow is sync'd
-  //bool otak; // can take from overflow
 
   u64 itrs;  // interaction count
 } TM;
@@ -273,7 +279,7 @@ Loc term_loc(Term term);
 // Memory operations log
 static u64 *MEMBUFF = NULL;
 enum : u32 {
-  MLOG_SIZ = 4096 * TPC * sizeof(u64) * 3,
+  MLOG_SIZ = (1 << 17) * TPC * sizeof(u64) * 3,
   MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
 };
 
@@ -301,7 +307,8 @@ static u32 u64_lo(u64 u) {
 #define MOP_LOAD 0x02
 #define MOP_STOR 0x03
 
-__attribute__((unused))
+#ifdef MEMLOG
+
 static const char* mop_str(u32 mop) {
   switch (mop) {
   case MOP_EXCH: return "EXCH";
@@ -311,7 +318,6 @@ static const char* mop_str(u32 mop) {
   }
 }
 
-#ifdef MEMLOG
 static void mlog_init() {
   if (MEMBUFF == NULL) {
     MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_SIZ);
@@ -380,7 +386,10 @@ static void mlog_dump_term(FILE* fp, u64 cntr, u64 e, u32 tag, Loc loc, u32 loc_
           tag_to_str(tag), loc, mlog_loc(e) + loc_offset);
 }
 
+static u32 ndmp = 0;
+
 static void mlog_dump_entry(FILE *fp, u64 cntr, u64 e, u64 locs) {
+  ndmp += 1;
   u32 mop = mlog_mop(e);
   Loc t1_loc = u64_hi(locs);
   Loc t2_loc = u64_lo(locs);
@@ -450,6 +459,9 @@ static void mlog_dump(const char* fn) {
       mlog_dump_range(fp, ini, off, end, &nlog);
     }
   }
+  
+  fprintf(stderr, "mlog: dumped %u entries\n", ndmp);
+
   fclose(fp);
 }
 
@@ -504,7 +516,8 @@ void mlog_exit() {
   cancel_threads();
   fprintf(stderr, "done\n");
   TM *tm = tms[0];
-  fprintf(stderr, "%d mput %u of LEN %u\n", thread_id, tm->mput, MLOG_LEN);
+  fprintf(stderr, "%d mput %u of LEN %u, wrap %u\n", thread_id,
+          tm->mput, MLOG_LEN, (u32)tm->mwrp);
   mlog_dump("memlog.txt");
 #endif
   exit(1);
@@ -543,7 +556,6 @@ TM *tm_new(u64 tid) {
   tm->bful = false;
   tm->buse = false;
   tm->ouse = false;
-  //tm->otak = false;
   tm->osyn = false;
 
   return tm;
@@ -623,14 +635,15 @@ static Term term_offset_loc(Term term, Loc offset) {
 
 #ifdef DEBUG
 static int mop_debug = 0; // memory operations
-static int thd_debug = 0; // threading
-static int bty_debug = 0; // booty bag
+//static int thd_debug = 0; // threading
 #endif
-static int oflw_debug = 0; // overflow
+__attribute__((unused))
+static int bty_debug = 1; // booty bag
+static int oflw_debug = 1; // overflow
 
 __attribute__((unused))
 static const char* term_str(char* buf, Term term) {
-  sprintf(buf, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
+  snprintf(buf, 64, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
           (u32)term_lab(term), (u32)term_loc(term));
   return buf;
 }
@@ -678,7 +691,7 @@ void set(Loc loc, Term term) {
 static Pair take_pair(Loc loc, bool bty) {
   Pair pair = *(Pair*)&BUFF[loc];
   
-  //#define VOID_TEST
+  #define VOID_TEST
 
   // Debugging
 #if defined(MEMLOG) || defined(VOID_TEST)
@@ -698,7 +711,8 @@ static Pair take_pair(Loc loc, bool bty) {
   //*(Pair*)&BUFF[loc] = (Pair)ZERO;
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
-    mlog_exit();
+    exit_stacktrace();
+    //    mlog_exit();
   }
 #endif
   
@@ -706,6 +720,15 @@ static Pair take_pair(Loc loc, bool bty) {
 }
 
 static void set_pair(Loc loc, Pair pair) {
+#if 1
+  Term neg = pair_neg(pair);
+  Term pos = pair_pos(pair);
+  if ((neg == 0) || (pos == 0)) {
+    fprintf(stderr, "%d set_pair: void term\n", thread_id);
+    mlog_exit();
+  }
+#endif
+
   *((Pair*)&BUFF[loc]) = pair;
   MLOG_PAIR(MOP_STOR, loc, pair);
 }
@@ -720,8 +743,20 @@ static Loc bbag_ini(u32 tid) {
   return RBAG + bbag_offset(tid);
 }
 
+static bool bbag_empty(TM *tm) {
+  return tm->bput == 0;
+}
+
+static bool bbag_full(TM *tm) {
+  return tm->bput == BBAG_LEN;
+}
+
 static Loc rbag_ini(u32 tid) {
   return bbag_ini(tid) + BBAG_LEN;
+}
+
+static bool rbag_empty(TM *tm) {
+  return tm->rput == 0;
 }
 
 static Loc rnod_ini(u32 tid) {
@@ -733,9 +768,12 @@ static Loc oflw_offset(u32 oidx) {
 }
 
 static Loc oflw_ini(u32 tid, u32 oidx) {
-  // maybe some tricky trick when we know odix can only be zero or one
   return bbag_ini(tid) + oflw_offset(oidx);
 }
+
+static bool oflw_empty(TM *tm) {
+  return (tm->oput[0] == 0) && (tm->oput[1] == 0);
+}  
 
 // Allocator
 // ---------
@@ -779,7 +817,7 @@ static u32 bbag_get(u32 tid) {
 
 static Loc get_push_offset(TM *tm, bool force_oflw) {
   if (force_oflw && tm->ouse) {
-    #if 0 || defined(DEBUG)
+    #if defined(DEBUG)
     if (oflw_debug) {
       fprintf(stderr, "%u pushing to overflow %u @ %u\n", tm->tid,
             0u+tm->opid, tm->oput[tm->opid]);
@@ -790,22 +828,33 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
   }
 
   // Only push to booty bag if we aren't stealing
-  if (tm->buse && !tm->bful && (tm->bput < BBAG_LEN) && (tm->sid == TPC)) {
-    #ifdef DEBUG
-    fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
+  if (tm->buse && !tm->bful && !bbag_full(tm) && (tm->sid == TPC)) {
+    #if defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
+    }
     #endif
 
     return tm->bput;
   }
 
-  #ifdef DEBUG
-  fprintf(stderr, "%u pushing to RBAG @ %u\n", tm->tid, tm->rput);
+  #if 0 && defined(DEBUG)
+  fprintf(stderr, "%u pushing to RBAG @ %u buse %u\n", tm->tid,
+          tm->rput, (u32)tm->buse);
   #endif
   // Push to RBAG
   return BBAG_LEN + tm->rput;
 }
 
 static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
+#if 1
+  if ((neg == 0) || (pos == 0)) {
+    fprintf(stderr, "%d rbag_push: void term\n", thread_id);
+    exit_stacktrace();
+    //    mlog_exit();
+  }
+#endif
+
   Loc off = get_push_offset(tm, force_oflw);
   Loc loc = bbag_ini(tm->tid) + off;
 
@@ -838,25 +887,22 @@ _Thread_local u64 noflw = 0;
 static Loc redex_pop_loc(TM* tm) {
   // Must check overflow bag first when sync'd
   if (tm->ouse) {
-
     if (tm->osyn) {
       // Overflow is sync'd so we can pop
       u32 oidx = 1u - tm->opid;
-      u32 oput = tm->oput[oidx];
-      if (oput > 0) {
-        oput -= 2;
-        tm->oput[oidx] = oput;
+      if (tm->oput[oidx] > 0) {
+        tm->oput[oidx] -= 2;
         
-        #if 0 || defined(DEBUG)
+        #if defined(DEBUG)
         if (oflw_debug) {
           fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
-                  oidx, oput);
+                  oidx, tm->oput[oidx]);
         }
         #endif
 
         ++noflw;
         
-        return oflw_ini(tm->tid, oidx) + oput;
+        return oflw_ini(tm->tid, oidx) + tm->oput[oidx];
       }
     }
 
@@ -880,10 +926,22 @@ static Loc redex_pop_loc(TM* tm) {
     if (tm->sid == tm->tid) {
       tm->bput -= 2;
     }
+
+    #if defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%u popping from booty bag @ %u\n", tm->tid, tm->spop);
+    }
+    #endif
+
     return bbag_ini(tm->sid) + tm->spop;
   } else if (tm->rput > 0) {
     // Pop from non-empty RBAG
     tm->rput -= 2;
+
+#if 0 && defined(DEBUG)
+    fprintf(stderr, "%u popping from RBAG @ %u\n", tm->tid, tm->rput);
+#endif
+
     return rbag_ini(tm->tid) + tm->rput;
   } else {
     // Steal from someone else
@@ -1046,6 +1104,14 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i+1], offset);
+#if 1
+  if ((neg == 0) || (pos == 0)) {
+    fprintf(stderr, "%d expand: void term\n", thread_id);
+    exit_stacktrace();
+    //    mlog_exit();
+  }
+#endif
+
     rbag_push(tm, neg, pos, false);
   }
   return root;
@@ -1101,13 +1167,13 @@ static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Term bod = take(port(2, b_loc));
 
   // Magic to make race condition appear more frequently
-  bool buse = tm->buse;
-  tm->buse = false;
+  //bool buse = tm->buse;
+  //tm->buse = false;
 
   move(tm, var, arg);
   move(tm, ret, bod);
 
-  tm->buse = buse;
+  //tm->buse = buse;
   return true;
 }
 
@@ -1562,7 +1628,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
-  bool res = false;
   bool processed = true;
 
   switch (neg_tag) {
@@ -1585,7 +1650,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
           // Assumption broken. May not matter, but I want to know.
           fprintf(stderr, "APPREF root node is not a LAM, %s\n",
                   tag_to_str(term_tag(lam)));
-          mlog_exit();
+          exit(1);
         }
         // force push to overflow buffer
         rbag_push(tm, neg, lam, true);
@@ -1718,9 +1783,10 @@ static bool interact(TM *tm, Term neg, Term pos) {
 
   if (!processed) {
     unprocessed_itrs[neg_tag * 16 + pos_tag] = 1;
+    return false;
   }
 
-  return res;
+  return true;
 }
 
 static void show_unprocessed_itrs() {
@@ -1749,8 +1815,10 @@ static bool sequential_step(TM* tm) {
   return true;
 }
  
+// don't allow idling if our booty bag is marked full (stealable)
+// because it introduces weirdness that's easier to just ignore for now
 static bool can_idle(TM *tm) {
-  return (tm->oput[0] == 0) && (tm->oput[1] == 0);
+  return oflw_empty(tm) && rbag_empty(tm) && bbag_empty(tm) && !tm->bful;
 }
  
 static bool set_idle(bool was_busy) {
@@ -1775,26 +1843,30 @@ static bool try_steal(TM *tm) {
   if (!tm->buse) return false;
 
   if (tm->bput > 0) {
-    // Our booty bag has something in it
-    // TODO: combine these two conditions into one compound condition
-    if (tm->bput < BBAG_LEN) {
-      // Booty bag isn't full, so we can steal without atomics
+    // Either our booty bag has something in it, or it was stolen and
+    // it had something in it when we dropped it.
+    if (!tm->bful) {
+      // We're holding it, so we can steal without atomics
       tm->spop = tm->bput;
       tm->sid = tm->tid;
 
-      #ifdef DEBUG
-      fprintf(stderr, "%u stealing own non-empty booty bag\n", tm->tid);
+      #if 1 || defined(DEBUG)
+      if (bty_debug) {
+        fprintf(stderr, "%u stealing own non-full booty bag\n", tm->tid);
+      }
       #endif
       return true;
     } else {
-      // To steal from our own full bag, we need to atomic swap
+      // Try to pick up our dropped bag - only works if nobody stole it.
       if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
         tm->bful = false;
         tm->spop = tm->bput; // will always be BBAG_LEN
         tm->sid = tm->tid;
 
-        #ifdef DEBUG
-        fprintf(stderr, "%u stole own full booty bag\n", tm->tid);
+        #if 1 || defined(DEBUG)
+        if (bty_debug) {
+          fprintf(stderr, "%u stole own full booty bag\n", tm->tid);
+        }
         #endif
         return true;
       }
@@ -1809,9 +1881,11 @@ static bool try_steal(TM *tm) {
     tm->sid = vic;
     tm->sgud += 1;
 
-#ifdef DEBUG
-    fprintf(stderr, "%u stole t%u's booty bag\n", tm->tid, tm->sid);
-#endif
+    #ifdef DEBUG
+    if (bty_debug) {
+      fprintf(stderr, "%u stole t%u's booty bag\n", tm->tid, tm->sid);
+    }
+    #endif
 
     return true;
   }
@@ -1832,23 +1906,26 @@ static bool timeout(u64 tick) {
   return false;
 }
 
-static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
-  Pair pair = take_pair(loc, from_bty);
-
+//static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
+static bool lala_and_interact(TM *tm, Pair pair, bool from_bty) {
+  // TODO just absolutely intolerable hack
   if (from_bty && (tm->spop == 0)) {
     // The booty bag we stole just became empty
-
     if (tm->sid != tm->tid) {
       // It was another threads bag - signal that it can be recovered now
       bbag_set(tm->sid, EMPTY, memory_order_relaxed);
 
-#ifdef DEBUG
-      fprintf(stderr, "%u emptied t%u's stolen booty bag\n", tm->tid, tm->sid);
-#endif
+      #if defined(DEBUG)
+      if (bty_debug) {
+        fprintf(stderr, "%u emptied t%u's stolen booty bag\n", tm->tid, tm->sid);
+      }
+      #endif
     } else {
-#ifdef DEBUG
-      fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
-#endif
+      #if 1 || defined(DEBUG)
+      if (bty_debug) {
+        fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
+      }
+      #endif
     }
 
     // No longer stealing
@@ -1862,6 +1939,7 @@ static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
 #include <mach/mach.h>
 #include <mach/thread_policy.h>
 
+__attribute__((unused))
 void setup_thread_for_pcore(int thread_id) {
     // Set high QoS first
     pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
@@ -1873,6 +1951,7 @@ void setup_thread_for_pcore(int thread_id) {
                      (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
 }
 
+ __attribute__((unused))
 void setup_thread_for_ecore(int thread_id) {
     // Set lower QoS
     pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
@@ -1884,86 +1963,128 @@ void setup_thread_for_ecore(int thread_id) {
                      (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
 }
 
-
 struct SIMPLE_SYNC {
+  a64 requested;
   a64 arrived;
   a64 departed;
+  a64 generation;
 } ss;
 
-static bool sync_arrive(u32 tid) {
-  u64 prev_arrived = atomic_fetch_add_explicit(&ss.arrived, 1, memory_order_relaxed);
-  if (prev_arrived + 1 == TPC) {
-    // Last to arrive
-    atomic_store_explicit(&ss.departed, 1ULL, memory_order_release);
-    atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
+ __attribute__((unused))
+static void sync_clear_requests() {
+  atomic_store_explicit(&ss.requested, ZERO, memory_order_relaxed);
+}
+
+static bool sync_requested() {
+  return atomic_load_explicit(&ss.arrived, memory_order_relaxed) > 0;
+}
+
+static _Thread_local u64 my_gen = 0;
+
+static bool sync_arrive() {
+  u64 prev_cnt = atomic_fetch_add_explicit(&ss.arrived, 1, memory_order_release);
+  if ((prev_cnt + 1) == TPC) {
+    if (oflw_debug) {
+      fprintf(stderr, "%d last to arrive @ %" PRIu64 "\n", thread_id, my_gen);
+    }
     return true;
+  }  if (oflw_debug) {
+
+    fprintf(stderr, "%d arrived @ %" PRIu64 "\n", thread_id, my_gen);
   }
   return false;
 }
 
+static bool sync_wait_arrivals() {
+  return atomic_load_explicit(&ss.arrived, memory_order_relaxed) == TPC;
+}
+
 _Thread_local u32 nsync = 0;
 
-static bool sync_depart(bool departed) {
-  if (!departed) {
-    if (atomic_load_explicit(&ss.arrived, memory_order_relaxed) > 0) {
-      return false;
+__attribute__((unused))
+static bool sync_depart() {
+  u64 prev_cnt = atomic_fetch_add_explicit(&ss.departed, 1, memory_order_relaxed);
+  if ((prev_cnt + 1) == TPC) {
+    atomic_exchange_explicit(&ss.arrived, ZERO, memory_order_acquire);
+    // exchange needed to sync with all other releases
+    // or use atomic store + thread_fence acquire
+    atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
+
+    if (oflw_debug) {
+      fprintf(stderr, "%d last to depart %" PRIu64 ", setting to gen %" PRIu64 "\n",
+              thread_id, my_gen, my_gen + 1);
     }
-    /*u64 dep_cnt = */atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
-    //technically a "sync done" shortcut for 1 person here, i just dont know
-    // how to return it.
+
+    my_gen += 1;
+    atomic_store_explicit(&ss.generation, my_gen, memory_order_relaxed);
+    return true;
+  } else if (oflw_debug) {
+    fprintf(stderr, "%d departed from %" PRIu64 "\n", thread_id, my_gen);
   }
+  my_gen += 1;
+  return false;
+}
+
+static bool sync_wait_departures() {
+  // while a thread is waiting to depart, it can't process any other operations
+  // because some threads may have already departed and "published" new data that
+  // it hasn't synchronized with yet;
+  if (atomic_load_explicit(&ss.generation, memory_order_relaxed) < my_gen) {
+    return false;
+  }
+  nsync += 1;
+  atomic_thread_fence(memory_order_acquire);
+  //atomic_load_explicit(&ss.arrived, memory_order_acquire);
   return true;
 }
 
-static bool sync_wait(bool departed) {
-  if (departed) {
-    u64 dep_cnt = atomic_load_explicit(&ss.departed, memory_order_relaxed);
-    if ((dep_cnt % TPC) == 0) {
-      nsync += 1;
-      atomic_thread_fence(memory_order_acquire);
-      return false;
-    }
-  }
-  return true;
-}
+#define SYNC_REQ_SIZE 1024
 
-static u64 work_quantum(u64 time, bool ecore) {
-  // 24000 = 1ms
-  u64 work = 2400;
-  if (ecore) {
-    work = work / 2;
+// more booty bag 'marked full' weirdness i'm trying to bicycle around
+// allow sync requests if booty bag appears non-empty, if it's been marked
+// full
+static bool request_sync(TM *tm) {
+  Loc oput = tm->oput[tm->opid];
+  bool req = (oput >= SYNC_REQ_SIZE) ||
+    ((oput > 0) && rbag_empty(tm) && (bbag_empty(tm) || tm->bful));
+  if (req) {
+    //sync_add_request();
+    
+    if (oflw_debug) {
+      fprintf(stderr, "%u requesting sync \n", // @ %u, stop taking from overflow %u len %u\n",
+              tm->tid); // , nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
+    }
+
   }
-  return time + work;
+  return req;
 }
 
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
 
+  #if 0
   bool ecore = false;
-
   if (thread_id < 4) {
     setup_thread_for_pcore(thread_id);
   } else {
     setup_thread_for_ecore(thread_id);
     ecore = true;
   }
+  #endif
   
   TM *tm = tms[thread_id];
 
   // Wait until after injection to turn these on
   tm->buse = true;
   tm->ouse = true;
-  //tm->otak = true;
 
   // Overflow synchronization
   // TODO: Could moving these to global to reduce code in this funciton
+  bool all_arrived = false;
   bool syncing = false;
-  bool departed = false;
   u64 do_nothing = 0;
+  u64 last_work_tick = 0;
 
-  u64 time = read_cntvct();
-  u64 next_time = work_quantum(time, ecore);
-  
   u64  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
@@ -1973,59 +2094,70 @@ static void* thread_func(void* arg) {
 
     tick += 1;
 
+    if (busy && ((tick - last_work_tick) % 65536 == 0)) {
+      fprintf(stderr, "%u busy doing nothing syncing %u osyn %u bbag %u bful %u stolen %u rbag %u oflw %u oflw_other %u\n",
+              tm->tid, (u32) syncing, (u32)tm->osyn, tm->bput, (u32) tm->bful, (u32)(tm->sid < TPC),
+              tm->rput, tm->oput[tm->opid], tm->oput[1-tm->opid]);
+    }
+
     if (tm->ouse) {
       if (!syncing) {
-        time = read_cntvct();
-        if (time >= next_time) {
-          //u64 tick_mod = tick % OFLW_SYNC;
-          //if ((tick_mod == 0) && !syncing) {
-          departed = sync_arrive(tm->tid);
-          syncing = true;
-          
-          if (0 || oflw_debug) {
-            fprintf(stderr, "%u syncing @ %u, stop taking from overflow %u len %u\n",
-                    tm->tid, nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
-            time = read_cntvct();
+        syncing = sync_requested();
+        if (!syncing) {
+          if (request_sync(tm)) {
+            all_arrived = sync_arrive();
+            syncing = true;
+
+            if (oflw_debug && all_arrived) {
+              fprintf(stderr, "%u last to arrive upon simultaneous request @ %" PRIu64 "\n",
+                      tm->tid, my_gen);
+            }
           }
-          next_time = work_quantum(time, ecore);
-          
-          // TODO: assert(oput[oidx] == 0);
+        } else {
+          all_arrived = sync_arrive();
+          syncing = true;
+        }
+        if (syncing) {
           tm->opid = 1 - tm->opid;
-          // Just in case it's not empty (it should be)
-          //tm->otak = false;
           tm->osyn = false;
         }
-      } else { //if (syncing) {
-        departed = sync_depart(departed);
-        syncing = sync_wait(departed);
-        if (!syncing) {
+      }
+      if (syncing) {
+        if (!all_arrived) {
+          all_arrived = sync_wait_arrivals();
+
+          if (all_arrived && oflw_debug) {
+            fprintf(stderr, "%u all arrived @ %" PRIu64 "\n", tm->tid, my_gen);
+          }
+        }
+        if (all_arrived) {
+          bool all_departed = sync_depart();
+          while (!all_departed) {
+            all_departed = sync_wait_departures();
+            sched_yield();
+          }
+          syncing = false;
+          all_arrived = false;
           tm->osyn = true;
-          //tm->otak = true;
-          // Reset tick count to ensure we empty oveflow before next sync point
-          // TODO: could also try something like:
-          //if ((tick % sync) < oput[1-oidx]) 
-          // just enough rope to hang ourselves
-          #if 0
-          u32 oflw_len = (tm->oput[1-tm->opid] / 2);
-          if (tick_mod < oflw_len) {
-            tick = OFLW_SYNC - oflw_len;
+
+          if (oflw_debug) {
+            fprintf(stderr, "%u synched @ %" PRIu64 ", can take from overflow %u len %u\n",
+                    tm->tid, my_gen, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
           }
-          #else
-          //tick = 0;
-          #endif
-          if (0 || oflw_debug) {
-            fprintf(stderr, "%u synched @ %u, can take from overflow %u len %u\n", // tick %" PRIu64 "\n",
-                    tm->tid, nsync, 1u-tm->opid, tm->oput[1u-tm->opid]/2); // , tick);
-          }
-          u64 time = read_cntvct();
-          next_time = work_quantum(time, ecore);
         }
       }
     }
 
-    bool from_bty = tm->spop > 0; // haxor
+    // much hax
+    u32 oidx = 1u-tm->opid;
+    u32 oput = tm->oput[oidx];
+    u32 spop = tm->spop;
+    bool from_bty = tm->spop > 0; // this is so bad.
+
     Loc loc = redex_pop_loc(tm);
     if (loc) {
+      last_work_tick = 0;
+
       busy = set_busy(busy);
 
       // We *think* booty bag is full, but it may have been stolen and emptied
@@ -2038,23 +2170,36 @@ static void* thread_func(void* arg) {
         #endif
       }
 
-      take_and_interact(tm, loc, from_bty);
+      Pair pair = take_pair(loc, from_bty);
+      if (!lala_and_interact(tm, pair, from_bty)) {
+        Tag neg_tag = term_tag(pair_neg(pair));
+        Tag pos_tag = term_tag(pair_pos(pair));
+        if (!((neg_tag == ERA) && (pos_tag == REF))) {
+          from_bty = spop > tm->spop;
+          bool oflw = oput > tm->oput[1-tm->opid];
+          fprintf(stderr, "%u uprocessed %s%s bty %u oflw %u\n", tm->tid,
+                  tag_to_str(neg_tag), tag_to_str(pos_tag),
+                  (u32)from_bty, (u32)oflw);
+        }
+      }
 
-      if (!tm->bful && (tm->bput == BBAG_LEN)) {
-        // Booty bag was filled by the preceding interaction
-        // Signal that it can be stolen aka drop()
-        bbag_set(tm->tid, FULL, memory_order_release);
-        tm->bful = true;
+      if (!tm->bful && bbag_full(tm)) {
+        // Booty bag is full, but hasn't been marked full
+        if (!rbag_empty(tm)) { //|| !oflw_empty(tm)) {
+          bbag_set(tm->tid, FULL, memory_order_release);
+          tm->bful = true;
+        }
       }
     } else {
       do_nothing += 1;
-      if (can_idle(tm)) {
+
+      if (busy && can_idle(tm)) {
         busy = set_idle(busy);
-        if (!busy && !try_steal(tm)) {
-          sched_yield();
-          if (timeout(tick))
-            break;
-        }
+      }
+      if (!try_steal(tm) && !busy) {
+        sched_yield();
+        if (timeout(tick))
+          break;
       }
     }
   }
@@ -2071,8 +2216,11 @@ static void* thread_func(void* arg) {
 
 static void parallel_normalize() {
   atomic_store_explicit(&net.idle, TPC-1, memory_order_relaxed);
+
+  atomic_store_explicit(&ss.requested, ZERO, memory_order_relaxed);
   atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
   atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
+  atomic_store_explicit(&ss.generation, ZERO, memory_order_relaxed);
 
   for (u64 i = 0; i < TPC; i++) {
     /*int rc = */pthread_create(&threads[i], NULL, thread_func, (void*)i);

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -15,6 +15,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#define DEBUG
+
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
 typedef pthread_t thread_t;
@@ -42,6 +44,21 @@ void segv_handler(int sig) {
   backtrace_symbols_fd(array, size, STDERR_FILENO);
   exit(1);
 }
+
+#ifdef __APPLE__
+// Use explicit file-scope assembly to prevent compiler from optimizing out
+
+extern uint64_t read_cntvct(void);
+__asm__(
+    ".global _read_cntvct\n"
+    ".global read_cntvct\n"
+    "_read_cntvct:\n"
+    "read_cntvct:\n"
+    //"   isb\n"
+    "   mrs x0, cntvct_el0\n"
+    "   ret\n"
+);
+#endif
 
 // Constants
 #define VAR 0x01
@@ -124,17 +141,13 @@ enum : u64 {
   TPC = 10,
 
   // Various redex bag sizes within the heap to choose from. The remaining
-  // percentage is used for node storage. Named for the % of heap used.
-  RBAG_12_PCT = (HEAP_SIZE / 8),
-  RBAG_25_PCT = (HEAP_SIZE / 4),
-  RBAG_50_PCT = (HEAP_SIZE / 2),
-  RBAG_75_PCT = (HEAP_SIZE - (HEAP_SIZE / 4)),
-  // TODO: something like: RBAG_1024_DEX, for 1024 redex per thread
+  // percentage is used for node storage.
+  RBAG_4096 = 4096 * TPC * sizeof(Term),
 
   //////////////////////////
   // Choose a RBAG size here
   //////////////////////////
-  RBAG_SIZE = RBAG_25_PCT,
+  RBAG_SIZE = RBAG_4096,
 };
 
 enum : u32 {
@@ -193,7 +206,7 @@ typedef struct TM {
   Loc rput; // next rbag push index
   Loc bput; // next (owned) bbag push index
   Loc bpop; // next (stolen) bbag pop index
-  u32 btid; // tid from which bbag was stolen
+  u32 sid; // tid from which bbag was stolen
   u32 sgud; // successful steals
   u32 sbad; // failed steals
 
@@ -205,6 +218,7 @@ typedef struct TM {
 
   u64 itrs; // interaction count
   bool buse; // use booty bag
+  bool bful; 
 } TM;
 
 //static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
@@ -242,14 +256,8 @@ Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
 //#define MEMLOG // comment out to disable
-//#define LOCLOG
-
-#if defined(MEMLOG) && defined(LOCLOG)
-#error "define MEMLOG -or- LOCLOG not both"
-#endif
 
 #ifdef MEMLOG
-
 // Memory operations log
 static u64 *MEMBUFF = NULL;
 enum : u32 {
@@ -394,22 +402,6 @@ static void mlog_dump(const char* fn) {
   fclose(fp);
 }
 
-#ifdef __APPLE__
-
-// Use explicit file-scope assembly to prevent compiler from optimizing out
-
-extern uint64_t read_cntvct(void);
-__asm__(
-    ".global _read_cntvct\n"
-    ".global read_cntvct\n"
-    "_read_cntvct:\n"
-    "read_cntvct:\n"
-    //"   isb\n"
-    "   mrs x0, cntvct_el0\n"
-    "   ret\n"
-);
-#endif
-
 static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl, bool force_t2) {
   static bool at_end = false;
 
@@ -420,10 +412,7 @@ static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl, bool forc
     MEMBUFF[pos] = read_cntvct();
     MEMBUFF[pos+1] = mlog_entry(tid, mop, tm->itid, loc, lvl, tm->i1_tag,
                                 tm->i2_tag, term_tag(t1), term_tag(t2));
-
-#if 1
     MEMBUFF[pos+2] = (u64)term_loc(t1) << 32 | term_loc(t2);
-#endif
 
     tm->mput += 3;
   } else if (!at_end) {
@@ -462,11 +451,11 @@ TM *tm_new(u64 tid) {
   tm->tid = tid;
   tm->bput = 0;
   tm->bpop = 0;
-  tm->btid = 0;
+  tm->sid = TPC;
   tm->sgud = 0;
   tm->sbad = 0;
   tm->buse = false;
-  tm->bfld = false;
+  tm->bful = false;
 
   return tm;
 }
@@ -539,7 +528,6 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
-//#define DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
 static int bty_debug = 0; // booty bag
@@ -557,20 +545,8 @@ Term swap_lvl(Loc loc, Term term, u32 lvl) {
   return got;
 }
 
-Term swap_seq_cst(Loc loc, Term term, u32 lvl) {
-  Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_acquire);
-  MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
-  return got;
-}
-
 Term swap(Loc loc, Term term) {
   return swap_lvl(loc, term, 0);
-}
-
-Term get(Loc loc) {
-  Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
-  MLOG(MOP_LOAD, loc, term, 0);
-  return term;
 }
 
 Term take(Loc loc) {
@@ -579,9 +555,10 @@ Term take(Loc loc) {
   return term;
 }
 
-void set_release(Loc loc, Term term) {
-  atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_release);
-  MLOG(MOP_STOR, loc, term, 0);
+Term get(Loc loc) {
+  Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
+  MLOG(MOP_LOAD, loc, term, 0);
+  return term;
 }
 
 void set(Loc loc, Term term) {
@@ -600,10 +577,9 @@ static Pair take_pair(Loc loc, bool bty) {
   TM *tm = tms[thread_id];
   tm->i1_tag = term_tag(neg);
   tm->i2_tag = term_tag(pos);
-  tm->itid = bty ? tm->btid : tm->tid;
+  tm->itid = bty ? tm->sid : tm->tid;
 
   MLOG_PAIR(MOP_LOAD, loc, pair, 0);
-
 #endif
 
 //#define VOID_TEST
@@ -625,11 +601,27 @@ static void set_pair(Loc loc, Pair pair) {
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
 
-// Allocator
-// ---------
+static Loc bbag_offset(u32 tid) {
+  return tid * RBAG_LEN;
+}
+
+static Loc bbag_ini(u32 tid) {
+  return RBAG + bbag_offset(tid);
+}
+
+static Loc rbag_ini(u32 tid) {
+  return bbag_ini(tid) + BBAG_LEN;
+}
 
 static Loc rnod_ini(u32 tid) {
   return tid * NODE_LEN;
+}
+
+// Allocator
+// ---------
+
+static u64 align(u64 align, u64 val) {
+  return (val + align - 1) & ~(align - 1);
 }
 
 static Loc node_alloc(TM *tm, u32 cnt) {
@@ -651,10 +643,6 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   return loc;
 }
 
-static bool bty_time(TM* tm) {
-  return (tm->bpop == 0) && tm->buse;
-}
- 
 static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
                               memory_order success_order) {
   return atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
@@ -670,17 +658,9 @@ static u32 bbag_get(u32 tid) {
 }
 
 static Loc get_push_offset(TM *tm) {
-  // TODO: this is a little weird, but made sense yesterday. we only consider
-  // pushing to our booty bag if we aren't popping from a stolen booty bag.
-  // probably the assumption was that if we stole a bag, our bag must be empty
-  // (or stolen). in the empty case, it might be better perf to just push to it.
-  // in the stolen case, what if the bag we stole is our own? also might be 
-  // better perf in this case if we just put ot it.
-  if (bty_time(tm)) {
-    if (tm->bput < BBAG_LEN) {
-      // Booty bag isn't full, push to it
-      return tm->bput;
-    }
+  // Only push to booty bag if we aren't stealing
+  if (tm->buse && !tm->bful && (tm->bput < BBAG_LEN) && (tm->sid == TPC)) {
+    return tm->bput;
   }
   // Push to RBAG
   return BBAG_LEN + tm->rput;
@@ -688,20 +668,13 @@ static Loc get_push_offset(TM *tm) {
 
 static void rbag_push(TM *tm, Term neg, Term pos) {
   Loc off = get_push_offset(tm);
-  bool bty = off < BBAG_LEN;
-  Loc loc = RBAG + tm->tid * RBAG_LEN + off;
+  bool to_bty = off < BBAG_LEN;
+  Loc loc = bbag_ini(tm->tid) + off;
 
-  Pair pair = pair_new(neg, pos);
-  set_pair(loc, pair);
+  set_pair(loc, pair_new(neg, pos));
 
-  //log_pair_loc(MOP_STOR, pair, loc);
-
-  if (bty) {
+  if (to_bty) {
     tm->bput += 2;
-    if (tm->bput == BBAG_LEN) {
-      // Booty bag was filled during this interaction
-      tm->bfld = true;
-    }
   } else {
     //#ifdef DEBUG
     bool free_global = tm->rput < RBAG_LEN - BBAG_LEN - 1;
@@ -713,7 +686,6 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
     tm->rput += 2;
   }
-  return loc;
 }
 
 static Pair rbag_pop(TM* tm) {
@@ -721,16 +693,15 @@ static Pair rbag_pop(TM* tm) {
     // Pop from stolen, non-empty booty bag
     tm->bpop -= 2;
 
-    // If we stole our own booty bag, adjust push index as well
-    if (tm->btid == tm->tid) {
+    // If we are stealing from our own booty bag, adjust push index as well
+    if (tm->sid == tm->tid) {
       tm->bput -= 2;
     }
-
-    return RBAG + tm->btid * RBAG_LEN + tm->bpop;
+    return bbag_ini(tm->sid) + tm->bpop;
   } else if (tm->rput > 0) {
     // Pop from non-empty RBAG
     tm->rput -= 2;
-    return RBAG + tm->tid * RBAG_LEN + BBAG_LEN + tm->rput;
+    return rbag_ini(tm->tid) + tm->rput;
   } else {
     // Steal from someone else
     return 0;
@@ -798,22 +769,6 @@ Loc ffi_rnod_end() {
   return atomic_load(&net.nods);
 }
 
-static Loc bbag_offset(u32 tid) {
-  return tid * RBAG_LEN;
-}
-
-static Loc bbag_ini(u32 tid) {
-  return RBAG + bbag_offset(tid);
-}
-
-static Loc rbag_ini(u32 tid) {
-  return bbag_ini(tid) + BBAG_LEN;
-}
-
-static u64 align(u64 align, u64 val) {
-  return (val + align - 1) & ~(align - 1);
-}
-
 int cmp_u32(const void *a, const void *b) {
   u32 aa = *(const u32*)a;
   u32 bb = *(const u32*)b;
@@ -834,7 +789,7 @@ u32 upr_bnd(Loc *locs, u32 cnt, Loc tgt) {
   return lft;
 }
 
-u32 dup_bod(Term *src, Term *dst, u32 nsrc) {
+static u32 dup_bod(Term *src, Term *dst, u32 nsrc) {
   Term lam = src[0];
   if (term_tag(lam) != LAM) return 0;
 
@@ -895,7 +850,7 @@ void def_new(char *name) {
   // assert((mnod_ini + rnod_cnt * 3) < RBAG);
   Term *nodes = &BUFF[node_ini];
 
-  u32 ndup = dup_bod(BUFF, nodes, rnod_cnt);
+  u32 ndup = 0; //dup_bod(BUFF, nodes, rnod_cnt);
 
   if (ndup == 0) {
     nodes = BUFF;
@@ -977,7 +932,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
-    Term pos = term_offset_loc(rbag[i + 1], offset);
+    Term pos = term_offset_loc(rbag[i+1], offset);
     rbag_push(tm, neg, pos);
   }
   return root;
@@ -996,7 +951,7 @@ static void boot(Loc def_idx) {
 // Atomic Linker
 
 static Term get_loop(Loc loc) {
-  fprintf(stderr, "get_loop\n");
+  //fprintf(stderr, "get_loop\n");
   // TOOD: tick/timeout
   while (1) {
     Term term = get(loc);
@@ -1015,7 +970,7 @@ static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
     Term far = swap_lvl(term_loc(pos), neg, lvl);
     if (far == 0) {
-      far = get_loop(term_loc(pos + 1));
+      //far = get_loop(term_loc(pos + 1));
     }
     if (term_tag(far) != SUB) {
       move_lvl(tm, term_loc(pos), far, lvl + 1);
@@ -1043,8 +998,6 @@ static inline void move(TM *tm, Loc neg_loc, Term pos) {
 
 // Interactions
 static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
-  return true;
-
   Term arg = take(port(1, a_loc));
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
@@ -1052,7 +1005,7 @@ static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
 
   // Magic to make race condition appear more frequently
   bool buse = tm->buse;
-  tm->buse = false;
+  //  tm->buse = false;
 
   move(tm, var, arg);
   move(tm, ret, bod);
@@ -1512,8 +1465,6 @@ static void interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
-  fprintf(stderr, "%s%s\n", tag_to_str(neg_tag), tag_to_str(pos_tag));
-
   bool processed = true;
 
   switch (neg_tag) {
@@ -1713,14 +1664,15 @@ static bool try_steal(TM *tm) {
     if (tm->bput < BBAG_LEN) {
       // Booty bag isn't full, so we can steal without atomics
       tm->bpop = tm->bput;
-      tm->btid = tm->tid;
+      tm->sid = tm->tid;
 
       return true;
     } else {
-      // To steal from our own full bag, we need to take back ownership
+      // To steal from our own full bag, we need to atomic swap
       if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
         tm->bpop = tm->bput; // will always be BBAG_LEN
-        tm->btid = tm->tid;
+        tm->sid = tm->tid;
+        tm->bful = false;
 
         return true;
       }
@@ -1732,7 +1684,7 @@ static bool try_steal(TM *tm) {
   u32 vic = get_victim(tm);
   if (bbag_compare_swap(vic, FULL, STOLEN, memory_order_acquire)) {
     tm->bpop = BBAG_LEN;
-    tm->btid = vic;
+    tm->sid = vic;
     tm->sgud += 1;
     return true;
   }
@@ -1754,9 +1706,11 @@ static bool timeout(u32 tick) {
 static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
   Pair pair = take_pair(loc, from_bty);
 
-  if (from_bty && (tm->bpop == 0) && (tm->btid != tm->tid)) {
+  if (from_bty && (tm->bpop == 0) && (tm->sid != tm->tid)) {
     // The last pair was just popped from a stolen booty bag
-    bbag_set(tm->btid, EMPTY, memory_order_relaxed);
+    bbag_set(tm->sid, EMPTY, memory_order_relaxed);
+    tm->sid = TPC;
+    tm->bful = false;
   }
   
   interact(tm, pair_neg(pair), pair_pos(pair));
@@ -1775,27 +1729,28 @@ static void* thread_func(void* arg) {
   while (true) {
     tick += 1;
 
-    bool bty = tm->bpop > 0; // haxor
+    bool from_bty = tm->bpop > 0; // haxor
     // TODO: I think i can adjust rbag_pop() to not include RBAG, and thus pass
     // down the "loc < BBAG_LEN" logic to here in order to determine if this
-    // was a booty-bag pop. That'll move some tid vs. btid logic here though.
+    // was a booty-bag pop. That'll move some tid vs. sid logic here though.
     Loc loc = rbag_pop(tm);
     if (loc) {
       busy = set_busy(busy);
 
-      if (tm->bput == BBAG_LEN) {
-        // We *think* booty bag is full, but it may have been stolen and emptied
-        if (bbag_get(tm->tid) == EMPTY) {
-          tm->bput = 0;
-        }
+      // We *think* booty bag is full, but it may have been stolen and emptied
+      if (tm->bful && (bbag_get(tm->tid) == EMPTY)) {
+        tm->bput = 0;
+        tm->sid = TPC;
+        tm->bful = false;
       }
 
-      take_and_interact(tm, loc, bty);
+      take_and_interact(tm, loc, from_bty);
 
-      if (tm->bfld) {
+      if (!tm->bful && (tm->bput == BBAG_LEN)) {
         // Booty bag was filled by the preceding interaction
         bbag_set(tm->tid, FULL, memory_order_release);
-        tm->bfld = false;
+        tm->sid = TPC; // weird
+        tm->bful = true;
       }
     } else {
       busy = set_idle(busy);

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -19,7 +19,6 @@
 //#define SUMMARY
 
 //#define DEBUG
-//#define MEMLOG
 //#define VOIDTEST
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
@@ -233,14 +232,6 @@ typedef struct TM {
 
   Loc oput[2]; // next oflw bag push indices
   
-#ifdef MEMLOG
-  u32 mput;
-  u32 itid;
-  u8 i1_tag;
-  u8 i2_tag;
-  bool mwrp; // memlog wrapped
-#endif
-
   bool buse; // can use booty bag
   bool bhld; // when we KNOW booty bag ctrl word is HELD
              // (in some cases it may be HELD but we don't know)
@@ -277,8 +268,6 @@ static _Thread_local int thread_id = 0;
 
 // Debugging
 static char *tag_to_str(Tag tag);
-static char *bty_ctrl_str(u32 ctrl);
-static void dump_term(Loc loc);
 
 static Term pair_pos(Pair pair);
 static Term pair_neg(Pair pair);
@@ -289,252 +278,13 @@ void dump_buff();
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
-#ifdef MEMLOG
-// Memory operations log
-static u64 *MEMBUFF = NULL;
-enum : u32 {
-  MLOG_SIZ = (1 << 17) * TPC * sizeof(u64) * 3,
-  MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
-};
-
-//static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
-#define MLOG_PAIR(mop, loc, pair)       mlog_pair((u32)thread_id, mop, loc, pair)
-#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
-#else
-#define MLOG(mop, loc, t1, t2)
-#define MLOG_PAIR(mop, loc, pair)
-#define MLOG_LVL(mop, loc, lvl, t1, t2)
-#endif
-
-static u32 u64_hi(u64 u) {
-  return (u >> 32) & 0xFFFFFFFF;
+static u32 u64_hi(u64 e) {
+  return e >> 32;
 }
 
-__attribute__((unused))
-static u32 u64_lo(u64 u) {
-  return u & 0xFFFFFFFF;
-}
-
-// Memory operations
-#define MOP_EXCH 0x01
-#define MOP_LOAD 0x02
-#define MOP_STOR 0x03
-
-#ifdef MEMLOG
-
-static const char* mop_str(u32 mop) {
-  switch (mop) {
-  case MOP_EXCH: return "EXCH";
-  case MOP_LOAD: return "LOAD";
-  case MOP_STOR: return "STOR";
-  default: return "????";
-  }
-}
-
-static void mlog_init() {
-  if (MEMBUFF == NULL) {
-    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_SIZ);
-  }
-}
-
-static void mlog_free() {
-  if (MEMBUFF != NULL) {
-    free(MEMBUFF);
-    MEMBUFF = NULL;
-  }
-}
-
-// i1_tag: 4, i2_tag: 4, lvl: 5, op: 2, t1_tag: 4, t2_tag: 4, tid: 4, sid: 4
-
-static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
-                      u32 i1_tag, u32 i2_tag, u32 t1_tag, u32 t2_tag) {
-  u64 hi = (i1_tag << 27) | ((i2_tag & 0xF) << 23) |
-    ((lvl & 0x1F) << 18) | ((mop & 0x3) << 16) |
-    ((t1_tag & 0xF) << 12) | ((t2_tag & 0xF) << 8) |
-    ((tid & 0xF) << 4) | (sid & 0xF);
-  return hi << 32 | loc;
-}
-
-static u32 mlog_i1_tag(u64 e) {
-  return (u64_hi(e) >> 27);
-}
-
-static u32 mlog_i2_tag(u64 e) {
-  return (u64_hi(e) >> 23) & 0xF;
-}
-
-static u32 mlog_lvl(u64 e) {
-  return (u64_hi(e) >> 18) & 0x1F;
-}
-
-static u32 mlog_mop(u64 e) {
-  return (u64_hi(e) >> 16) & 0x3;
-}
-
-static u32 mlog_t1_tag(u64 e) {
-  return (u64_hi(e) >> 12) & 0xF;
-}
-
-static u32 mlog_t2_tag(u64 e) {
-  return (u64_hi(e) >> 8) & 0xF;
-}
-
-static u32 mlog_tid(u64 e) {
-  return (u64_hi(e) >> 4) & 0xF;
-}
-
-__attribute__((unused))
-static u32 mlog_sid(u64 e) {
-  return u64_hi(e) & 0xF;
-}
-
-static u32 mlog_loc(u64 e) {
-  return u64_lo(e);
-}
-
-static void mlog_dump_term(FILE* fp, u64 cntr, u64 e, u32 tag, Loc loc, u32 loc_offset) {
-  fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%u\n", cntr, mlog_tid(e),
-          tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
-          mop_str(mlog_mop(e)), mlog_lvl(e),
-          tag_to_str(tag), loc, mlog_loc(e) + loc_offset);
-}
-
-static u32 ndmp = 0;
-
-static void mlog_dump_entry(FILE *fp, u64 cntr, u64 e, u64 locs) {
-  ndmp += 1;
-  u32 mop = mlog_mop(e);
-  Loc t1_loc = u64_hi(locs);
-  Loc t2_loc = u64_lo(locs);
-  if ((mop == MOP_LOAD) || (mop == MOP_STOR)) {
-    mlog_dump_term(fp, cntr, e, mlog_t1_tag(e), t1_loc, 0);   // T1 
-    /*
-    if ((mlog_t2_tag(e) != 0) || (t2_loc != 0)) {
-      mlog_dump_term(fp, cntr, e, mlog_t2_tag(e), t2_loc, 1); // T2
-    }
-    */
-  } else {
-    fprintf(fp, "%" PRIu64 ",%u,%s%s,%s,%u,%s,%u,%s,%u,%u\n", cntr, mlog_tid(e),
-            tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
-            mop_str(mop), mlog_lvl(e), tag_to_str(mlog_t1_tag(e)), t1_loc, 
-            tag_to_str(mlog_t2_tag(e)), t2_loc, mlog_loc(e));
-  }
-}
-
-static u32 mlog_dump_range(FILE *fp, u32 ini, u32 off, u32 end, u32 *nlog) {
-  for (; (off + 2) < end; off += 3) {
-    u32 pos  = ini + off;
-    u64 cntr = MEMBUFF[pos]; 
-    u64 e    = MEMBUFF[pos+1]; // entry
-    u64 locs = MEMBUFF[pos+2];
-    mlog_dump_entry(fp, cntr, e, locs);
-    if (nlog) (*nlog)++;
-  }
-  return off;
-}
-
-static void mlog_dump(const char* fn) {
-  FILE *fp = fopen(fn, "w");
-  if (fp == NULL) {
-    perror("mlog_dump: Error opening file");
-    return;
-  }
-
-  for (u32 tid = 0; tid < TPC; tid++) {
-    TM *tm = tms[tid];
-    u32 ini = tid * MLOG_LEN;
-    u32 off = tm->mwrp ? tm->mput : 0;
-    u32 end = tm->mwrp ? MLOG_LEN : tm->mput;
-    u32 nlog = 0;
-
-    off = mlog_dump_range(fp, ini, off, end, &nlog);
-    if (tm->mwrp) {
-      if (off < end) {
-        u64 words[3];
-        u32 idx = 0;
-        for (; off < end; off++, idx++) {
-          if (idx > 2) {
-            fprintf(stderr, "idx %u!\n", idx);
-            exit(1);
-          }
-          words[idx] = MEMBUFF[ini + off];
-        }
-        off = 0;
-        end = tm->mput;
-        for (; idx < 3; idx++, off++) {
-          words[idx] = MEMBUFF[ini + off];
-        }
-        mlog_dump_entry(fp, words[0], words[1], words[2]);
-        nlog += 1;
-      } else {
-        off = 0;
-      }
-      mlog_dump_range(fp, ini, off, end, &nlog);
-    }
-  }
-  
-  fprintf(stderr, "mlog: dumped %u entries\n", ndmp);
-
-  fclose(fp);
-}
-
-static u64 mlog_get_word(u32 idx, TM *tm, u32 mop, Loc loc, u32 lvl, Term t1, Term t2) {
-  switch (idx) {
-  case 0: return read_cntvct();
-  case 1: return mlog_entry(tm->tid, mop, tm->itid, loc, lvl, tm->i1_tag,
-                            tm->i2_tag, term_tag(t1), term_tag(t2));
-  case 2: return (u64)term_loc(t1) << 32 | term_loc(t2); // TODO new_u64()
-  default:
-    break;
-  }
-  fprintf(stderr, "bad idx %u\n", idx);
-  exit(1);
-}
-
-static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
-  TM *tm = tms[tid];
-  for (u32 i = 0; i < 3; i++, tm->mput++) {
-    if (tm->mput == MLOG_LEN) {
-      tm->mput = 0;
-      tm->mwrp = true;
-    }
-    u32 pos = tid * MLOG_LEN + tm->mput;
-    MEMBUFF[pos] = mlog_get_word(i, tm, mop, loc, lvl, t1, t2);
-  }
-}
-
-static void mlog_pair(u32 tid, u32 mop, Loc loc, Pair pair) {
-  mlog(tid, mop, loc, pair_neg(pair), 0, 0);
-  mlog(tid, mop, loc+1, pair_pos(pair), 0, 0);
-}
-
-#endif // MEMLOG
-
-void cancel_threads() {
-  for (int i = 0; i < TPC; i++) {
-    if (i != thread_id) {
-      pthread_cancel(threads[i]);
-    }
-  }
-  for (int i = 0; i < TPC; i++) {
-    if (i != thread_id) {
-      pthread_join(threads[i], NULL);
-    }
-  }
-}
-
-void mlog_exit() {
-#ifdef MEMLOG
-  fprintf(stderr, "%d mlog_exit() cancelling threads...", thread_id);
-  cancel_threads();
-  fprintf(stderr, "done\n");
-  TM *tm = tms[0];
-  fprintf(stderr, "%d mput %u of LEN %u, wrap %u\n", thread_id,
-          tm->mput, MLOG_LEN, (u32)tm->mwrp);
-  mlog_dump("memlog.txt");
-#endif
-  exit(1);
+__attribute((unused))
+static u32 u64_lo(u64 e) {
+  return e & 0xFFFFFFFF;
 }
 
 // TM/BB operations
@@ -542,11 +292,6 @@ void tm_reset(TM *tm) {
   tm->rput = 0;
   tm->nput = 0;
   tm->itrs = 0;
-
-#ifdef MEMLOG
-  tm->mput = 0;
-  tm->mwrp = false;
-#endif
 }
 
 TM *tm_new(u64 tid) {
@@ -576,23 +321,9 @@ TM *tm_new(u64 tid) {
   return tm;
 }
 
-#if 0
-static BB *bb_new() {
-  size_t bb_siz = (sizeof(BB) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
-  BB *bb = aligned_alloc(CACH_SIZ, bb_siz);
-  if (bb == NULL) {
-    fprintf(stderr, "BB memory allocation failed\n");
-    exit(EXIT_FAILURE);
-  }
-  bb->ctrl = EMPTY;
-  return bb;
-}
-#endif
-
 static void alloc_static_data() {
   for (u64 t = 0; t < TPC; ++t) {
     tms[t] = tm_new(t);
-    //bbs[t] = bb_new();
   }
 }
 
@@ -648,10 +379,6 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
-#ifdef DEBUG
-static int mop_debug = 0; // memory operations
-//static int thd_debug = 0; // threading
-#endif
 __attribute__((unused))
 static int bty_debug = 0; // booty bag
 __attribute__((unused))
@@ -667,11 +394,11 @@ static const char* term_str(char* buf, Term term) {
 // Memory operations
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-  MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
+
   #ifdef VOIDTEST
   if (got == 0) {
     fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
-    mlog_exit();
+    exit_stacktrace();
   }
   #endif
   return got;
@@ -683,11 +410,11 @@ Term swap(Loc loc, Term term) {
 
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
-  MLOG(MOP_EXCH, loc, term, 0);
+
   #ifdef VOIDTEST
   if (term == 0) {
     fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
-    mlog_exit();
+    exit_stacktrace();
   }
   #endif
   return term;
@@ -695,38 +422,25 @@ Term take(Loc loc) {
 
 Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
-  MLOG(MOP_LOAD, loc, term, 0);
   return term;
 }
 
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-  MLOG(MOP_STOR, loc, term, 0);
+
 }
 
 static Pair take_pair(Loc loc) {
   Pair pair = *(Pair*)&BUFF[loc];
   
   // Debugging
-  #if defined(MEMLOG) || defined(VOIDTEST)
+  #if defined(VOIDTEST)
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
-  #endif
-
-  #if defined(MEMLOG)
-  TM *tm = tms[thread_id];
-  tm->i1_tag = term_tag(neg);
-  tm->i2_tag = term_tag(pos);
-  tm->itid = tm->id; // bty ? tm->sid : tm->tid;
-  #endif
-  MLOG_PAIR(MOP_LOAD, loc, pair);
-
-  #ifdef VOIDTEST
   //*(Pair*)&BUFF[loc] = (Pair)ZERO;
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
     exit_stacktrace();
-    //    mlog_exit();
   }
   #endif
   
@@ -739,12 +453,11 @@ static void set_pair(Loc loc, Pair pair) {
   Term pos = pair_pos(pair);
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d set_pair: void term\n", thread_id);
-    mlog_exit();
+    exit_stacktrace();
   }
   #endif
 
   *((Pair*)&BUFF[loc]) = pair;
-  MLOG_PAIR(MOP_STOR, loc, pair);
 }
 
 static Loc port(u64 n, Loc loc) { return n + loc - 1; }
@@ -779,20 +492,20 @@ static u32 bbag_get(u32 tid) {
   return atomic_load_explicit(&bbs[tid].ctrl, memory_order_relaxed);
 }
 
+// Drop a held, full booty bag (make it steal-able)
 static void bbag_drop(TM *tm) {
   #if defined(DEBUG)
   if (bty_debug) {
-    fprintf(stderr, "%u dropping bbag! bput %u rput %u\n", //added %u dexes,
+    fprintf(stderr, "%u dropping bbag! bput %u rput %u\n",
             tm->tid, tm->bput, tm->rput);
   }
   #endif
 
-  // TODO: compare_exchange from STOLEN for added safety
   bbag_set(tm->tid, DROPPED, memory_order_release);
   tm->bhld = false;
 }
 
-// attempt to recover a tossed (stolen, and emptied) booty bag
+// Attempt to recover a tossed (stolen, and emptied) booty bag
 static bool bbag_recover(TM *tm) {
   bool held = bbag_get(tm->tid) == HELD;
   if (held) {
@@ -808,9 +521,8 @@ static bool bbag_recover(TM *tm) {
   return held;
 }
 
-// attempt to pick up our own dropped booty bag. this is actually treated as
-// a form of "stealing" from self. it is the only condition under which popping
-// from our own bag is allowed.
+// Attempt to pick up our own dropped booty bag - this is treated as "stealing"
+// from ourself - the only way to pop from our own bag
 static bool bbag_pickup(TM *tm) {
   bool held = bbag_compare_swap(tm->tid, DROPPED, HELD, memory_order_relaxed);
   if (held) {
@@ -827,7 +539,7 @@ static bool bbag_pickup(TM *tm) {
   return held;
 }
 
-// attempt to steal another thread's dropped booty bag
+// Attempt to steal another thread's dropped booty bag
 static bool bbag_steal(TM *tm, u32 sid) {
   bool stole = bbag_compare_swap(sid, DROPPED, STOLEN, memory_order_acquire);
   if (stole) {
@@ -843,12 +555,11 @@ static bool bbag_steal(TM *tm, u32 sid) {
   return stole;
 }
 
-// toss the booty bag we stole from another thread and emptied
+// Toss the booty bag we stole from another thread and emptied
 static void bbag_toss(TM *tm) {
   #if defined(DEBUG)
   if (bty_debug) {
-    fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n",// removed %u dexes\n",
-            tm->tid, tm->sid);//, tm->srem);
+    fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n", tm->tid, tm->sid);
   }
   #endif
 
@@ -888,13 +599,6 @@ static u64 align(u64 align, u64 val) {
 }
 
 static Loc node_alloc(TM *tm, u32 cnt) {
-  #ifdef DEBUG
-  if (mop_debug) {
-    fprintf(stderr, "%u node alloc cnt: %u, nput: %u\n", tm->tid, cnt,
-            tm->nput);
-  }
-  #endif
-
   if (tm->nput + cnt >= NODE_LEN) {
     fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
             tm->tid, tm->nput, cnt, NODE_LEN);
@@ -948,7 +652,6 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d rbag_push: void term\n", thread_id);
     exit_stacktrace();
-    //    mlog_exit();
   }
   #endif
 
@@ -957,11 +660,9 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
 
   set_pair(loc, pair_new(neg, pos));
 
-  // TODO: adjust_put_idx(tm, off);
-
   #ifdef DEBUG
   if (off > BBAG_LEN) {
-    // pushed to RBAG
+    // Pushed to RBAG
     if (tm->rput >= RPUT_MAX-1) {
       fprintf(stderr, "%u rbag space exhausted\n", tm->tid);
       exit(1);
@@ -1004,7 +705,7 @@ static void oflw_sync(TM *tm) {
 }
 
 static Loc redex_pop_loc(TM* tm) {
-  // Must check overflow bag first when sync'd
+  // Check overflow bag first when sync'd
   if (tm->ouse) {
     Loc loc = oflw_pop_loc(tm);
     if (loc > 0) return loc;
@@ -1017,11 +718,10 @@ static Loc redex_pop_loc(TM* tm) {
   }
     
   if ((tm->sid < TPC) && (tm->spop > 0)) {
-    // Pop from stolen non-empty booty bag - but we could have 'stolen' our
-    // own HELD bag.
+    // Pop from stolen non-empty booty bag - but it may be our HELD bag
     tm->spop -= 2;
 
-    // If we are stealing from our own booty bag, adjust push index as well
+    // If we are stealing from our own bag, adjust push index as well
     if (tm->sid == tm->tid) {
       tm->bput -= 2;
     }
@@ -1043,6 +743,7 @@ static Loc redex_pop_loc(TM* tm) {
 
     return rbag_ini(tm->tid) + tm->rput;
   } else if (tm->ouse) {
+    // Finally, try a flip & sync of overflow bags
     if (tm->oput[tm->opid] > 0) {
       oflw_sync(tm);
       Loc loc = oflw_pop_loc(tm);
@@ -1080,10 +781,6 @@ void hvm_init() {
   #ifdef DEBUG
   signal(SIGSEGV, segv_handler);
   #endif
-
-  #ifdef MEMLOG
-  mlog_init();
-  #endif
 }
 
 void hvm_free() {
@@ -1092,10 +789,6 @@ void hvm_free() {
     BUFF = NULL;
   }
   free_static_data();
-
-  #ifdef MEMLOG
-  mlog_free();
-  #endif
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -1115,7 +808,6 @@ u64 inc_itr() {
     itrs += tms[i]->itrs;
   }
   return itrs;
-  //return atomic_load(&net.itrs);
 } 
 
 Loc ffi_rbag_ini() {
@@ -1134,7 +826,6 @@ Loc ffi_rnod_end() {
     nods += tms[i]->nput;
   }
   return nods;
-  //return atomic_load(&net.nods);
 }
 
 // Moves the global buffer and redex bag into a new def and resets
@@ -1217,7 +908,6 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     Loc loc = offset + n;
     Term term = term_offset_loc(nodes[n], offset);
     BUFF[loc] = term;
-    MLOG_LVL(MOP_STOR, loc, def_idx, term, 0);
   }
 
   for (u32 i = 0; i < rbag_len; i += 2) {
@@ -2026,10 +1716,6 @@ static void* thread_func(void* arg) {
   u64  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
-    #ifdef MEMLOG
-    pthread_testcancel();
-    #endif
-
     tick += 1;
 
     // Try to recover stolen and emptied booty bag
@@ -2108,10 +1794,6 @@ Term normalize(Term term) {
     parallel_normalize();
   }
 
-#ifdef MEMLOG
-  mlog_dump("memlog.txt");
-#endif
-
   return get(0);
 }
 
@@ -2156,17 +1838,6 @@ static char *tag_to_str(Tag tag) {
 
   default:
     return "???";
-  }
-}
-
-__attribute__((unused))
-static char *bty_ctrl_str(u32 ctrl) {
-  switch (ctrl) {
-  case HELD:    return "HELD";
-  case DROPPED: return "DROPPED";
-  case STOLEN:  return "STOLEN";
-  //case TOSSED:  return "TOSSED";
-  default:      return "???";
   }
 }
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -1086,7 +1086,6 @@ static inline void move(TM *tm, Loc neg_loc, Term pos) {
 
 // Interactions
 static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
-  return true;
 
   Term arg = take(port(1, a_loc));
   Loc ret = port(2, a_loc);
@@ -1563,8 +1562,6 @@ static void interact(TM *tm, Term neg, Term pos) {
   Tag pos_tag = term_tag(pos);
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
-
-  fprintf(stderr, "%s%s\n", tag_to_str(neg_tag), tag_to_str(pos_tag));
 
   bool processed = true;
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -113,7 +113,7 @@ enum : u64 {
 
   // Various redex bag sizes within the heap to choose from. The remaining
   // percentage is used for node storage. Named for the % of heap used.
-  // TODO: RBAG_10_PCT
+  RBAG_12_PCT = (HEAP_SIZE / 8),
   RBAG_25_PCT = (HEAP_SIZE / 4),
   RBAG_50_PCT = (HEAP_SIZE / 2),
   RBAG_75_PCT = (HEAP_SIZE - (HEAP_SIZE / 4)),
@@ -135,8 +135,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 96,
-  BBAG_FRQ = 1U << 0
+  BBAG_LEN = 98
 };
 
 typedef struct Net {
@@ -205,11 +204,162 @@ static TM *tms[TPC];
 static BB *bbs[TPC];
 static thread_t threads[TPC];
 
+static _Thread_local int thread_id = 0;
+
 // Debugging
 static char *tag_to_str(Tag tag);
 static char *bty_ctrl_str(u32 ctrl);
 void dump_term(Loc loc);
 void dump_buff(TM *tm);
+
+#define TERMSTR_BUFSIZ 128
+
+static const char* term_str(char* buf, Term term);
+
+#define MEMLOG // comment out to disable
+
+#ifdef MEMLOG
+
+// Memory operations
+#define MOP_EXCH 0x01
+#define MOP_LOAD 0x02
+#define MOP_STOR 0x03
+
+// Memory operations log
+static u32 *MEMBUFF = NULL;
+static a64 MLOG_END = 0;
+static u32 MLOG_MAX = 1U << 24;
+
+//static _Thread_local u64 rbag_loc = 0;
+#define MLOG(mop, sid, loc, t1, t2) mlog((u32)thread_id, mop, sid, loc, t1, t2)
+#else
+#define MLOG(mop, sid, loc, t1, t2)
+#endif
+
+#ifdef MEMLOG
+static void mlog_init() {
+  if (MEMBUFF == NULL) {
+    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_MAX * sizeof(u64));
+  }
+  //memset(MEMBUFF, 0, MLOG_MAX * sizeof(a64));
+  MLOG_END = 0;
+}
+
+static void mlog_free() {
+  if (MEMBUFF != NULL) {
+    free(MEMBUFF);
+    MEMBUFF = NULL;
+  }
+}
+
+// op:3, loc: 7, tid: 4, sid: 4
+static u32 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc) {
+  return (mop << 15) | ((loc & 0x7F) << 8) | ((tid & 0xF) << 4) | (sid & 0xF);
+}
+
+static u32 mlog_mop(u32 e) {
+  return e >> 15;
+}
+
+static u32 mlog_loc(u32 e) {
+  return (e >> 8) & 0x7F;
+}
+
+static u32 mlog_tid(u32 e) {
+  return (e >> 4) & 0xF;
+}
+
+static u32 mlog_sid(u64 e) {
+  return e & 0xF;
+}
+
+#if 0
+// hi 32 bits: tid: 5, mop: 2, itr: 5, term_tag: 8
+// lo 32 bits: rbag_loc
+static u64 mlog_entry(u32 tid, u32 mop, u32 itr, Term term, u64 rbag_loc) {
+  u64 hi = (tid << 15) | ((mop & 0x3) << 13) | ((itr & 0x1F) << 8) | term_tag(term);
+  return (hi << 32) | (rbag_loc & 0xFFFFFFFF);
+}
+
+static u32 mlog_entry_hi(u64 entry) {
+  return (entry >> 32) & 0xFFFFFFFF;
+}
+
+static u32 mlog_itr(u64 entry) {
+  return (mlog_entry_hi(entry) >> 8) & 0x1F;
+}
+
+static u32 mlog_term_tag(u64 entry) {
+  return mlog_entry_hi(entry) & 0xFF;
+}
+
+static u32 mlog_rbag_loc(u64 entry) {
+  return entry & 0xFFFFFFFF;
+}
+
+static u32 mlog_loc(u64 locs) {
+  return (locs >> 32) & 0xFFFFFFFF;
+}
+
+static u32 mlog_term_loc(u64 locs) {
+  return locs & 0xFFFFFFFF;
+}
+#endif
+
+static const char* mop_str(u32 mop) {
+  switch (mop) {
+  case MOP_EXCH: return "EXCH";
+  case MOP_LOAD: return "LOAD";
+  case MOP_STOR: return "STOR";
+  default: return "????";
+  }
+}
+
+static void mlog_dump(const char* fn) {
+  FILE *fp = fopen(fn, "w");
+  if (fp == NULL) {
+    perror("mlog_dump: Error opening file");
+    return;
+  }
+  u32 end = atomic_load(&MLOG_END);
+  if (end > MLOG_MAX) end = MLOG_MAX;
+  for (u32 i = 0; i < end;) {
+    u32 e = MEMBUFF[i++]; // entry
+    Term t1 = *(Term*)&MEMBUFF[i];
+    i += 2;
+    Term t2 = *(Term*)&MEMBUFF[i];
+    i += 2;
+    char buf1[TERMSTR_BUFSIZ];
+    char buf2[TERMSTR_BUFSIZ];
+    fprintf(fp, "%u,%s,%u,%u,%s,%s\n", mlog_tid(e), mop_str(mlog_mop(e)),
+            mlog_sid(e), mlog_loc(e), term_str(buf1, t1), term_str(buf2, t2));
+  }
+  fclose(fp);
+}
+
+static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2) {
+  // ugly but acceptable load-test-add pattern for debug logging.
+  u32 end = atomic_load(&MLOG_END);
+  if (end + 5 < MLOG_MAX) {
+    end = atomic_fetch_add(&MLOG_END, 5UL);
+    if (end + 5 < MLOG_MAX) {
+      MEMBUFF[end] = mlog_entry(tid, mop, sid, loc);
+      end += 1;
+      *(Term*)&MEMBUFF[end] = t1;
+      end += 2;
+      *(Term*)&MEMBUFF[end] = t2;
+    }
+  }
+}
+#endif // MEMLOG
+
+void mlog_exit() {
+#ifdef MEMLOG
+  mlog_dump("memlog.txt");
+#endif
+  exit(1);
+}
+
 
 // TM/BS operations
 void tm_reset(TM *tm) {
@@ -219,6 +369,7 @@ void tm_reset(TM *tm) {
 }
 
 TM *tm_new(u64 tid) {
+  // make size a multiple of alignment
   size_t tm_siz = (sizeof(TM) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
   TM *tm = aligned_alloc(CACH_SIZ, tm_siz);
   if (tm == NULL) {
@@ -321,24 +472,18 @@ static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
 static int bty_debug = 0; // booty bag
 
-static _Thread_local int thread_id = 0;
-
-#define TERMSTR_BUFSIZ 128
-
 static const char* term_str(char* buf, Term term) {
   sprintf(buf, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
-          (int)term_lab(term), (int)term_loc(term));
+          (u32)term_lab(term), (u32)term_loc(term));
   return buf;
 }
-
-static bool good_loc(Loc loc) { return true; }
 
 // Memory operations
 Term swap(Loc loc, Term term) {
   Term res = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 
 #ifdef DEBUG
-  if (mop_debug && good_loc(loc)) {
+  if (mop_debug)) {
     char buf1[TERMSTR_BUFSIZ];
     char buf2[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d swap %u %s with %s\n", thread_id, loc,
@@ -353,7 +498,7 @@ Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
 
 #ifdef DEBUG
-  if (mop_debug && good_loc(loc)) {
+  if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d get %u %s\n", thread_id, loc, term_str(buf, term));
   }
@@ -366,7 +511,7 @@ Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
 
 #ifdef DEBUG
-  if (mop_debug && good_loc(loc)) {
+  if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d take %u %s\n", thread_id, loc, term_str(buf, term));
   }
@@ -379,7 +524,7 @@ void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 
 #ifdef DEBUG
-  if (mop_debug && good_loc(loc)) {
+  if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d set %u %s\n", thread_id, loc, term_str(buf, term));
   }
@@ -388,13 +533,21 @@ void set(Loc loc, Term term) {
 
 static Pair take_pair(Loc loc) {
 #if 0 || defined(ATOMIC)
+  #define VOID_TEST
   Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], VOID, __ATOMIC_RELAXED);
+#else
+  Pair pair = *(Pair*)&BUFF[loc];
+  //#define VOID_TEST
+  #ifdef VOID_TEST
+  *(Pair*)&BUFF[loc] = (Pair)VOID;
+  #endif
+#endif
+
+#ifdef VOID_TEST
   if (pair == 0) {
     fprintf(stderr, "%d VOID term taken\n", thread_id);
     exit(1);
   }
-#else
-  Pair pair = *(Pair*)&BUFF[loc];
 #endif
   
 #if 0 || defined(DEBUG)
@@ -451,33 +604,32 @@ static Loc node_alloc(TM *tm, u32 num) {
 }
 
 static bool bty_time(TM* tm) {
-  return tm->buse && (tm->bpop == 0) && (tm->itrs % BBAG_FRQ == 0);
+  return (tm->bpop == 0) && tm->buse;
 }
-
-static bool bbag_compare_swap(u32 tid, u32 *expected, u32 desired) {
-  u32 orig = *expected;
-
-  bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, expected,
-                 desired, memory_order_acquire, memory_order_relaxed);
+ 
+static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
+                              memory_order success_order) {
+  u32 orig = expect;
+  bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
+                 desire, success_order, memory_order_relaxed);
 
   if (bty_debug) {
     if (res) {
       fprintf(stderr, "%d swap of t%u's booty bag from %s to %s succeeded\n",
-              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desired));
-    } else {
-      if (0) {
-        fprintf(stderr, "%d swap of t%u's booty bag from %s to %s failed, it's %s\n",
-                thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desired),
-                bty_ctrl_str(*expected));
-      }
+              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire));
+    }
+    else if (0) {
+      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s failed, it's %s\n",
+              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desire),
+              bty_ctrl_str(expect));
     }
   }
 
   return res;
 }
 
-static void bbag_set(u32 tid, u32 val) {
-  atomic_store_explicit(&bbs[tid]->ctrl, val, memory_order_release);
+static void bbag_set(u32 tid, u32 val, memory_order order) {
+  atomic_store_explicit(&bbs[tid]->ctrl, val, order);
 
   if (bty_debug) {
     fprintf(stderr, "%d set t%u's booty bag to %s\n", thread_id, tid,
@@ -486,7 +638,7 @@ static void bbag_set(u32 tid, u32 val) {
 }
 
 static u32 bbag_get(u32 tid) {
-  u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_acquire);
+  u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
 
   if (0 && bty_debug) {
     fprintf(stderr, "%d got t%u's booty bag: %s\n", thread_id, tid,
@@ -497,10 +649,10 @@ static u32 bbag_get(u32 tid) {
 }
 
 static Loc get_push_offset(TM *tm) {
-  // Consider pushing to booty bag?
   if (bty_time(tm)) {
+    // Consider pushing to booty bag
     if (tm->bput >= BBAG_LEN) {
-      // Last we knew, BBAG was full. But maybe it's empty now.
+      // BBAG is full, last we checked. But maybe it's empty now
       if (bbag_get(tm->tid) == EMPTY) {
         tm->bput = 0;
 
@@ -511,22 +663,22 @@ static Loc get_push_offset(TM *tm) {
         return tm->bput;
       }        
     } else {
-      // BBAG isn't full, use it.
+      // BBAG isn't full, use it
       return tm->bput;
     }
   }
-  // Push to RBAG.
+  // Push to RBAG
   return BBAG_LEN + tm->rput;
 }
 
 static void rbag_push(TM *tm, Term neg, Term pos) {
-  #ifdef DEBUG
+#ifdef DEBUG
   bool free_global = tm->rput < RBAG_LEN - 1;
   if (!free_global) {
     fprintf(stderr, "rbag space exhausted\n");
     exit(1);
   }
-  #endif
+#endif
 
   Loc off = get_push_offset(tm);
   bool bty = off < BBAG_LEN;
@@ -542,7 +694,9 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   set_pair(loc, pair_new(neg, pos));
 
   if (bty) {
-    if (bty_debug) {
+    MLOG(MOP_STOR, tm->tid, tm->bput, neg, pos);
+
+    if (1 && bty_debug) {
       fprintf(stderr, "%u pushed to booty bag @ %u\n", tm->tid, tm->bput);
       char buf[TERMSTR_BUFSIZ];
       fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, neg));
@@ -551,7 +705,8 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
-      bbag_set(tm->tid, FULL);
+      atomic_thread_fence(memory_order_release);
+      bbag_set(tm->tid, FULL, memory_order_relaxed);
 
       if (0 && bty_debug) {
         fprintf(stderr, "%u booty bag full\n", tm->tid);
@@ -564,7 +719,7 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
 static Pair rbag_pop(TM* tm) {
   if (tm->bpop > 0) {
-    // If we have a stolen booty bag, use it
+    // We stole a booty bag, use it
     tm->bpop -= 2;
 
     // If stealing from own booty bag, adjust push index as well
@@ -579,7 +734,7 @@ static Pair rbag_pop(TM* tm) {
 
     return RBAG + tm->btid * RBAG_LEN + tm->bpop;
   } else if (tm->rput > 0) {
-    // Else if RBAG isn't empty, use it
+    // RBAG isn't empty, use it
     tm->rput -= 2;
     return RBAG + tm->tid * RBAG_LEN + BBAG_LEN + tm->rput;
   } else {
@@ -600,6 +755,10 @@ void hvm_init() {
 
   alloc_static_data();
 
+#ifdef MEMLOG
+  mlog_init();
+#endif
+
   #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
   fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
@@ -615,6 +774,11 @@ void hvm_free() {
     BUFF = NULL;
   }
   free_static_data();
+
+#ifdef MEMLOG
+  mlog_free();
+#endif
+
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -731,7 +895,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   Term root = term_offset_loc(nodes[0], offset);
 
-  // No redexes reference these nodes yet; therefore, safe to add un-atomically.
+  // No redexes reference these nodes yet; safe to add without atomics.
   // TODO: ensure nodes always 16-byte aligned to enable 128-bit stores
   #define STORE_128
   #ifndef STORE_128
@@ -748,9 +912,9 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     BUFF[loc] = term;
     #else
     Pair pair = *(Pair*)&nodes[n];
-    pair = pair_new(term_offset_loc(pair_neg(pair), offset),
-                    term_offset_loc(pair_pos(pair), offset));
-    *(Pair*)&BUFF[loc] = pair;
+    *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
+                                  term_offset_loc(pair_pos(pair), offset));
+
     #endif
 
 #ifdef DEBUG
@@ -1431,10 +1595,12 @@ static void sync_threads() {
 static bool set_idle(bool was_busy) {
   if (was_busy) {
     u32 idle = atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
+
+#ifdef DEBUG
     if (thd_debug) {
       fprintf(stderr, "%u set idle, was idle = %u\n", thread_id, idle);
     }
-
+#endif
   }
   return false;
 }
@@ -1442,9 +1608,12 @@ static bool set_idle(bool was_busy) {
 static bool set_busy(bool was_busy) {
   if (!was_busy) {
     u32 idle = atomic_fetch_sub_explicit(&net.idle, 1, memory_order_relaxed);
+
+#ifdef DEBUG
     if (thd_debug) {
       fprintf(stderr, "%u set busy, was idle = %u\n", thread_id, idle);
     }
+#endif
   }
   return true;
 }
@@ -1456,45 +1625,44 @@ static u32 get_victim(TM *tm) {
 static bool try_steal(TM *tm) {
   if (!tm->buse) return false;
 
-  // Check if our own booty bag has anything in it.
   if (tm->bput > 0) {
-    // If it's not full, we can steal without atomics.
+    // Our own booty bag has something in it
     if (tm->bput < BBAG_LEN) {
+      // Booty bag isn't full, so we can steal without atomics
       tm->bpop = tm->bput;
       tm->btid = tm->tid;
 
-      if (bty_debug) {
+      if (0 && bty_debug) {
         fprintf(stderr, "%u stealing own non-full booty bag, len = %u\n",
                 tm->tid, tm->bpop);
       }
 
       return true;
     } else {
-      u32 state = FULL;
-      if (bbag_compare_swap(tm->tid, &state, EMPTY)) {
+      // To steal from our own full bag, we need to take back ownership
+      if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
         tm->bpop = tm->bput; // BBAG_LEN, always
         tm->btid = tm->tid;
 
-        if (bty_debug) {
+        if (0 && bty_debug) {
           fprintf(stderr, "%u stealing own full booty bag, len = %u\n",
                   tm->tid, tm->bpop);
         }
 
         return true;
       } else {
-        if (bty_debug) {
-          fprintf(stderr, "%u failed to steal own full booty bag, state = %s\n",
-                  tm->tid, bty_ctrl_str(state));
+        if (0 && bty_debug) {
+          fprintf(stderr, "%u failed to steal own full booty bag\n",
+                  tm->tid); //, bty_ctrl_str(state));
         }
       }
     }
   }
 
-  // Nothing in our booty bag, or another thread stole it.
-  // Try to steal from another thread.
+  // Our booty bag is either empty, or another thread stole it.
+  // Try to steal another thread's full bag
   u32 vic = get_victim(tm);
-  u32 full = FULL;
-  if (bbag_compare_swap(vic, &full, STOLEN)) {
+  if (bbag_compare_swap(vic, FULL, STOLEN, memory_order_acquire)) {
     tm->bpop = BBAG_LEN;
     tm->btid = vic;
     tm->sgud += 1;
@@ -1516,9 +1684,11 @@ static bool check_timeout(u32 tick) {
     if (idle == TPC) {
      return true;
     }
+#ifdef DEBUG
     if (thd_debug) {
       fprintf(stderr, "%u idle, total: %u\n", thread_id, idle);
     }
+#endif
   }
   return false;
 }
@@ -1527,7 +1697,7 @@ static void* thread_func(void* arg) {
   thread_id = (u64)arg;
   TM *tm = tms[thread_id];
 
-  // Use booty bag. Wait to turn this on after injection.
+  // Wait until after injection to turn on booty bag usage
   // TODO: this could be a global net flag i think.
   tm->buse = true;
 
@@ -1547,7 +1717,9 @@ static void* thread_func(void* arg) {
       //bbag_maybe_empty(tm, prev_bpop);
 
       if (prev_bpop > 0) {
-        if (bty_debug) {
+        MLOG(MOP_LOAD, tm->btid, tm->bpop, pair_neg(pair), pair_pos(pair));
+
+        if (1 && bty_debug) {
           char buf[TERMSTR_BUFSIZ];
           fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
           fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
@@ -1555,17 +1727,17 @@ static void* thread_func(void* arg) {
 
         if (tm->bpop == 0) {
           if (tm->btid != tm->tid) {
-            // Mark stolen booty bag empty.
-            bbag_set(tm->btid, EMPTY);
-            
+            // Mark stolen booty bag empty
+            bbag_set(tm->btid, EMPTY, memory_order_relaxed);
+          
             if (0 && bty_debug) {
               fprintf(stderr, "%u finished popping from t%u's booty bag\n",
                       tm->tid, tm->btid);
             }
-          } else {
-            if (bty_debug) {
-              fprintf(stderr, "%u finished popping from own booty bag\n",
-                      tm->tid);
+          }
+          else {
+            if (0 && bty_debug) {
+              fprintf(stderr, "%u finished popping from own booty bag\n", tm->tid);
             }
           }
         }
@@ -1637,6 +1809,10 @@ Term normalize(Term term) {
   } else {
     parallel_normalize();
   }
+
+#ifdef MEMLOG
+  mlog_dump("memlog.txt");
+#endif
 
   return get(0);
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -21,20 +21,9 @@
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
-typedef pthread_t thread_t;
-
 int get_num_threads() {
   long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
   return (nprocs <= 1) ? 1 : 1 << (int)log2(nprocs);
-}
-
-int thread_create(pthread_t *thread, const pthread_attr_t *attr,
-                  void *(*start_routine)(void *), void *arg) {
-  return pthread_create(thread, attr, start_routine, arg);
-}
-
-int thread_join(pthread_t thread, void **retval) {
-  return pthread_join(thread, retval);
 }
 
 void segv_handler(int sig) {
@@ -146,18 +135,17 @@ enum : u64 {
   // Number of terms *per thread* for each overflow bag. There are two of them,
   // and they (currently) steal space from each thread's RBAG space.
   // NB: These numbers are a bit aggresive. Overflow of overflow could happen.
-  OFLW_LEN = 1024,
-  OFLW_SYNC = OFLW_LEN,
+  OFLW_LEN = 1 << 18,
+  OFLW_SYNC = 1024,
 
   // Various redex bag sizes within the heap to choose from. The remaining
-  // percentage is used for node storage.
-  //RBAG_4096 = 4096 * TPC * sizeof(Term),
-  RBAG_8192 = 8192 * TPC * sizeof(Term),
+  // percentage is used for node storage. Assumes 10 threads.
+  RBAG_TEST = (1 << 23) * TPC * sizeof(Pair),
 
   //////////////////////////
   // Choose a RBAG size here
   //////////////////////////
-  RBAG_SIZE = RBAG_8192,
+  RBAG_SIZE = RBAG_TEST,
 };
 
 enum : u32 {
@@ -262,7 +250,7 @@ typedef struct BB {
 
 static TM *tms[TPC];
 static BB bbs[TPC];
-static thread_t threads[TPC];
+static pthread_t threads[TPC];
 static uint8_t unprocessed_itrs[255] = { 0 };
 
 static _Thread_local int thread_id = 0;
@@ -505,7 +493,7 @@ void cancel_threads() {
   }
   for (int i = 0; i < TPC; i++) {
     if (i != thread_id) {
-      thread_join(threads[i], NULL);
+      pthread_join(threads[i], NULL);
     }
   }
 }
@@ -845,6 +833,8 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
   }
 }
 
+_Thread_local u64 noflw = 0;
+
 static Loc redex_pop_loc(TM* tm) {
   // Must check overflow bag first when sync'd
   if (tm->ouse) {
@@ -863,11 +853,14 @@ static Loc redex_pop_loc(TM* tm) {
                   oidx, oput);
         }
         #endif
+
+        ++noflw;
         
         return oflw_ini(tm->tid, oidx) + oput;
       }
     }
 
+#if 0
     // If the overflow put bag is full, don't allow any pops from anywhere.
     // Overflow will empty on next sync.
     u32 oput = tm->oput[tm->opid];
@@ -876,7 +869,7 @@ static Loc redex_pop_loc(TM* tm) {
       //fprintf(stderr, "%u no pops overflow %u full\n", tm->tid, tm->opid);
       return 0;
     }
-
+#endif
   }
     
   if (tm->spop > 0) {
@@ -1865,6 +1858,33 @@ static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
   return interact(tm, pair_neg(pair), pair_pos(pair));
 }
 
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/thread_policy.h>
+
+void setup_thread_for_pcore(int thread_id) {
+    // Set high QoS first
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+    
+    // Then try to bind to specific P-core
+    thread_affinity_policy_data_t policy;
+    policy.affinity_tag = thread_id; // 0-3 for P-cores
+    thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
+                     (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
+}
+
+void setup_thread_for_ecore(int thread_id) {
+    // Set lower QoS
+    pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
+    
+    // Bind to E-core
+    thread_affinity_policy_data_t policy;
+    policy.affinity_tag = thread_id; // 4-9 for E-cores
+    thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
+                     (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
+}
+
+
 struct SIMPLE_SYNC {
   a64 arrived;
   a64 departed;
@@ -1907,8 +1927,27 @@ static bool sync_wait(bool departed) {
   return true;
 }
 
+static u64 work_quantum(u64 time, bool ecore) {
+  // 24000 = 1ms
+  u64 work = 2400;
+  if (ecore) {
+    work = work / 2;
+  }
+  return time + work;
+}
+
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
+
+  bool ecore = false;
+
+  if (thread_id < 4) {
+    setup_thread_for_pcore(thread_id);
+  } else {
+    setup_thread_for_ecore(thread_id);
+    ecore = true;
+  }
+  
   TM *tm = tms[thread_id];
 
   // Wait until after injection to turn these on
@@ -1920,7 +1959,11 @@ static void* thread_func(void* arg) {
   // TODO: Could moving these to global to reduce code in this funciton
   bool syncing = false;
   bool departed = false;
+  u64 do_nothing = 0;
 
+  u64 time = read_cntvct();
+  u64 next_time = work_quantum(time, ecore);
+  
   u64  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
@@ -1931,22 +1974,28 @@ static void* thread_func(void* arg) {
     tick += 1;
 
     if (tm->ouse) {
-      u64 tick_mod = tick % OFLW_SYNC;
-      if ((tick_mod == 0) && !syncing) {
-        departed = sync_arrive(tm->tid);
-        syncing = true;
-        
-        if (0 || oflw_debug) {
-          fprintf(stderr, "%u syncing @ %u, stop taking from overflow %u len %u\n",
-                  tm->tid, nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
+      if (!syncing) {
+        time = read_cntvct();
+        if (time >= next_time) {
+          //u64 tick_mod = tick % OFLW_SYNC;
+          //if ((tick_mod == 0) && !syncing) {
+          departed = sync_arrive(tm->tid);
+          syncing = true;
+          
+          if (0 || oflw_debug) {
+            fprintf(stderr, "%u syncing @ %u, stop taking from overflow %u len %u\n",
+                    tm->tid, nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
+            time = read_cntvct();
+          }
+          next_time = work_quantum(time, ecore);
+          
+          // TODO: assert(oput[oidx] == 0);
+          tm->opid = 1 - tm->opid;
+          // Just in case it's not empty (it should be)
+          //tm->otak = false;
+          tm->osyn = false;
         }
-        
-        // TODO: assert(oput[oidx] == 0);
-        tm->opid = 1 - tm->opid;
-        // Just in case it's not empty (it should be)
-        //tm->otak = false;
-        tm->osyn = false;
-      } else if (syncing) {
+      } else { //if (syncing) {
         departed = sync_depart(departed);
         syncing = sync_wait(departed);
         if (!syncing) {
@@ -1956,15 +2005,20 @@ static void* thread_func(void* arg) {
           // TODO: could also try something like:
           //if ((tick % sync) < oput[1-oidx]) 
           // just enough rope to hang ourselves
+          #if 0
           u32 oflw_len = (tm->oput[1-tm->opid] / 2);
           if (tick_mod < oflw_len) {
             tick = OFLW_SYNC - oflw_len;
           }
+          #else
           //tick = 0;
+          #endif
           if (0 || oflw_debug) {
-            fprintf(stderr, "%u synched @ %u, can take from overflow %u len %u tick %" PRIu64 "\n",
-                    tm->tid, nsync, 1u-tm->opid, tm->oput[1u-tm->opid]/2, tick);
+            fprintf(stderr, "%u synched @ %u, can take from overflow %u len %u\n", // tick %" PRIu64 "\n",
+                    tm->tid, nsync, 1u-tm->opid, tm->oput[1u-tm->opid]/2); // , tick);
           }
+          u64 time = read_cntvct();
+          next_time = work_quantum(time, ecore);
         }
       }
     }
@@ -1992,12 +2046,15 @@ static void* thread_func(void* arg) {
         bbag_set(tm->tid, FULL, memory_order_release);
         tm->bful = true;
       }
-    } else if (can_idle(tm)) {
-      busy = set_idle(busy);
-      if (!busy && !try_steal(tm)) {
-        sched_yield();
-        if (timeout(tick))
-          break;
+    } else {
+      do_nothing += 1;
+      if (can_idle(tm)) {
+        busy = set_idle(busy);
+        if (!busy && !try_steal(tm)) {
+          sched_yield();
+          if (timeout(tick))
+            break;
+        }
       }
     }
   }
@@ -2006,8 +2063,8 @@ static void* thread_func(void* arg) {
   atomic_fetch_add(&net.itrs, tm->itrs);
 
   if (1) {
-    fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u\n",
-            tm->tid, tm->itrs, tm->sgud, tm->sbad);
+    fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u oflw %" PRIu64 " do_nothing %" PRIu64 "\n",
+            tm->tid, tm->itrs, tm->sgud, tm->sbad, noflw, do_nothing);
   }
   return NULL;
 }
@@ -2018,11 +2075,11 @@ static void parallel_normalize() {
   atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
 
   for (u64 i = 0; i < TPC; i++) {
-    /*int rc = */thread_create(&threads[i], NULL, thread_func, (void*)i);
+    /*int rc = */pthread_create(&threads[i], NULL, thread_func, (void*)i);
   }
 
   for (u64 i = 0; i < TPC; i++) {
-    thread_join(threads[i], NULL);
+    pthread_join(threads[i], NULL);
   }
 
   show_unprocessed_itrs();

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,43 +16,12 @@
 #include <string.h>
 #include <unistd.h>
 
-#define SUMMARY
+//#define SUMMARY
 //#define DEBUG
-//#define VOIDTEST
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
-int get_num_threads() {
-  long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
-  return (nprocs <= 1) ? 1 : 1 << (int)log2(nprocs);
-}
-
-void exit_stacktrace() {
-  void *array[10];
-  size_t size;
-  
-  size = backtrace(array, 10);
-  backtrace_symbols_fd(array, size, STDERR_FILENO);
-  exit(1);
-}
-
-void segv_handler(int sig) {
-  fprintf(stderr, "Error: signal %d:\n", sig);
-  exit_stacktrace();
-}
-
 #ifdef __APPLE__
-// Use explicit file-scope assembly to prevent compiler from optimizing out
-extern uint64_t read_cntvct(void);
-__asm__(
-    ".global _read_cntvct\n"
-    ".global read_cntvct\n"
-    "_read_cntvct:\n"
-    "read_cntvct:\n"
-    "   mrs x0, cntvct_el0\n"
-    "   ret\n"
-);
-
 // Store barrier
 extern void dmb_ishst(void);
 __asm__(
@@ -141,13 +110,13 @@ enum : u64 {
   // Threads per CPU
   TPC = 10,
 
-#ifdef __APPLE__
+  #ifdef __APPLE__
   // PCores and ECores total, and in-use
   PCOR_TOT = 4,
   ECOR_TOT = TPC - PCOR_TOT,
   PCOR = TPC < PCOR_TOT ? TPC : PCOR_TOT,
   ECOR = TPC > PCOR_TOT ? (TPC - PCOR) : 0,
-#endif
+  #endif
 
   // Misc
   ZERO = 0,
@@ -209,31 +178,27 @@ typedef struct TM {
   u32 tid;   // thread id
   Loc nput;  // next node allocation attempt index
   Loc rput;  // next rbag push index
-  u32 sid;   // tid from which bbag was stolen
   Loc bput;  // owned bbag push index
-  Loc spop;  // stolen bbag pop index + 2
 
-  u32 sgud;  // successful steal count
-  u32 sbad;  // failed steal count
+  u32 sid;   // tid from which bbag was stolen (may be our own)
+  Loc spop;  // stolen bbag pop index + 2
 
   Loc dput[2]; // next deferred bag push indices
   
-  uint16_t scnt;
-  uint16_t smax;
-  uint16_t stot;
-  uint16_t smsk;
-
   bool buse; // can use booty bag
   bool bhld; // when we KNOW booty bag ctrl word is HELD
              // (in some cases it may be HELD but we don't know)
 
-  u8   dpid; // dput idx we are pushing into
+  u8   dpid; // deferred bag idx we are pushing into
   bool duse; // can use deferred bag
   bool dsyn; // deferred bag is sync'd
 
-  u8   lvic;
-  u8   pvic;
-  u8   evic;
+  u8   lvic; // last failed steal attempt victim
+
+#ifdef __APPLE__
+  u8   pvic; // last failed PCore victim
+  u8   evic; // last failed ECore victim
+#endif // __APPLE__
 
   u64 itrs;  // interaction count
 } TM;
@@ -264,20 +229,10 @@ static Book BOOK = {
 static TM *tms[TPC];
 static BB bbs[TPC];
 static pthread_t threads[TPC];
-#ifdef DEBUG
-static uint8_t unprocessed_itrs[255] = { 0 };
-#endif
-
-static _Thread_local int thread_id = 0;
 
 // Debugging
 static char *tag_to_str(Tag tag);
 static const char* term_str(char* buf, Term term);
-
-__attribute__((unused))
-static int bty_debug = 0; // booty bag
-__attribute__((unused))
-static int dfer_debug = 0; // deferred bag
 
 // FFI functions
 void dump_buff();
@@ -296,7 +251,6 @@ void tm_reset(TM *tm) {
 }
 
 TM *tm_new(u64 tid) {
-  // make size a multiple of alignment
   TM *tm = aligned_alloc(CACH_SIZ, align(CACH_SIZ, sizeof(TM)));
   if (tm == NULL) {
     fprintf(stderr, "tm_new() memory allocation failed\n");
@@ -314,8 +268,6 @@ TM *tm_new(u64 tid) {
   // Stolen booty bag
   tm->sid = TPC;
   tm->spop = 0;
-  tm->sgud = 0;
-  tm->sbad = 0;
 
   // Deferred bag
   tm->dput[0] = 0;
@@ -324,15 +276,12 @@ TM *tm_new(u64 tid) {
   tm->duse = false;
   tm->dsyn = false;
 
-  // Last steal attempt thread ids
+  // Last failed steal attempt thread ids
   tm->lvic = TPC;
+#ifdef __APPLE__
   tm->pvic = tid % PCOR;
   tm->evic = (tid % ECOR) + PCOR;
-
-  tm->scnt = 0;
-  tm->smax = 0;
-  tm->stot = 0;
-  tm->smsk = 0;
+#endif // __APPLE__
 
   return tm;
 }
@@ -393,32 +342,15 @@ static Loc port(u32 n, Loc loc) { return n + loc - 1; }
 
 // Memory operations
 Term swap(Loc loc, Term term) {
-  Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-
-  #ifdef VOIDTEST
-  if (got == 0) {
-    fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
-    exit_stacktrace();
-  }
-  #endif
-  return got;
+  return atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 }
 
 Term take(Loc loc) {
-  Term term = atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
-
-  #ifdef VOIDTEST
-  if (term == 0) {
-    fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
-    exit_stacktrace();
-  }
-  #endif
-  return term;
+  return atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
 }
 
 Term get(Loc loc) {
-  Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
-  return term;
+  return atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
 }
 
 void set(Loc loc, Term term) {
@@ -426,32 +358,10 @@ void set(Loc loc, Term term) {
 }
 
 static Pair take_pair(Loc loc) {
-  Pair pair = *(Pair*)&BUFF[loc];
-  
-  // Debugging
-  #if defined(VOIDTEST)
-  Term neg = pair_neg(pair);
-  Term pos = pair_pos(pair);
-  //*(Pair*)&BUFF[loc] = (Pair)ZERO;
-  if ((neg == 0) || (pos == 0)) {
-    fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
-    exit_stacktrace();
-  }
-  #endif
-  
-  return pair;
+  return *(Pair*)&BUFF[loc];
 }
 
 static void set_pair(Loc loc, Pair pair) {
-  #ifdef VOIDTEST
-  Term neg = pair_neg(pair);
-  Term pos = pair_pos(pair);
-  if ((neg == 0) || (pos == 0)) {
-    fprintf(stderr, "%d set_pair: void term\n", thread_id);
-    exit_stacktrace();
-  }
-  #endif
-
   *((Pair*)&BUFF[loc]) = pair;
 }
 
@@ -487,13 +397,6 @@ static u32 bbag_get(u32 tid) {
 
 // Drop a held, full booty bag (make it steal-able)
 static void bbag_drop(TM *tm) {
-  #if defined(DEBUG)
-  if (bty_debug) {
-    fprintf(stderr, "%u dropping bbag! bput %u rput %u\n",
-            tm->tid, tm->bput, tm->rput);
-  }
-  #endif
-
   bbag_set(tm->tid, DROPPED, memory_order_release);
   tm->bhld = false;
 }
@@ -504,12 +407,6 @@ static bool bbag_recover(TM *tm) {
   if (held) {
     tm->bhld = true;
     tm->bput = 0;
-
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%u recovered empty stolen bbag!\n", tm->tid);
-    }
-    #endif
   }
   return held;
 }
@@ -522,12 +419,6 @@ static bool bbag_pickup(TM *tm) {
     tm->bhld = true;
     tm->spop = tm->bput; // will always be BBAG_LEN
     tm->sid = tm->tid;
-
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%d picked up our own dropped bbag!\n", tm->tid);
-    }
-    #endif
   }
   return held;
 }
@@ -538,12 +429,6 @@ static bool bbag_steal(TM *tm, u32 sid) {
   if (stole) {
     tm->spop = BBAG_LEN;
     tm->sid = sid;
-    
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%d stole t%u's bbag!\n", tm->tid, sid);
-    }
-    #endif
   }
   return stole;
 }
@@ -553,25 +438,11 @@ static bool bbag_looted(TM *tm) {
   return (tm->sid < TPC) && (tm->spop == 0);
 }
 
-// Return a stolen, empty booty bag:
-// * if it was stolen stolen from another thread, mark it HELD
-// * reset tm->sid to indicate we're no longer stealing
+// Return a stolen, empty booty bag
 static void bbag_return(TM *tm) {
   if (tm->sid != tm->tid) {
-    // It was another threads bag - reset state to HELD
+    // It was another thread's bag - reset state to HELD
     bbag_set(tm->sid, HELD, memory_order_relaxed);
-    
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n", tm->tid, tm->sid);
-    }
-    #endif
-  } else {
-    #if 0 || defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
-    }
-    #endif
   }
   // No longer stealing
   tm->sid = TPC;
@@ -624,14 +495,8 @@ static Loc node_alloc(TM *tm, u32 cnt) {
 }
 
 static Loc get_push_offset(TM *tm, bool dfer) {
+  // Push to deferred bag
   if (dfer && tm->duse) {
-    #if defined(DEBUG)
-    if (dfer_debug) {
-      fprintf(stderr, "%u pushing to deferred %u @ %u\n", tm->tid,
-            0u+tm->dpid, tm->dput[tm->dpid]);
-    }
-    #endif
-
     u32 dput = tm->dput[tm->dpid];
     tm->dput[tm->dpid] += 2;
     return dfer_offset(tm->dpid) + dput;
@@ -639,21 +504,11 @@ static Loc get_push_offset(TM *tm, bool dfer) {
 
   // Only push to booty bag if we aren't stealing
   if (tm->buse && tm->bhld && !bbag_full(tm) && (tm->sid == TPC)) {
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
-    }
-    #endif
-
     u32 bput = tm->bput;
     tm->bput += 2;
     return bput;
   }
 
-  #if 0 && defined(DEBUG)
-  fprintf(stderr, "%u pushing to RBAG @ %u buse %u\n", tm->tid,
-          tm->rput, (u32)tm->buse);
-  #endif
   // Push to RBAG
   u32 rput = tm->rput;
   tm->rput += 2;
@@ -661,13 +516,6 @@ static Loc get_push_offset(TM *tm, bool dfer) {
 }
 
 static void redex_push(TM *tm, Term neg, Term pos, bool dfer) {
-  #ifdef VOIDTEST
-  if ((neg == 0) || (pos == 0)) {
-    fprintf(stderr, "%d redex_push: void term\n", thread_id);
-    exit_stacktrace();
-  }
-  #endif
-
   Loc off = get_push_offset(tm, dfer);
   Loc loc = bbag_ini(tm->tid) + off;
 
@@ -695,23 +543,12 @@ static void redex_push(TM *tm, Term neg, Term pos, bool dfer) {
   #endif
 }
 
-//_Thread_local u64 noflw = 0;
-
 static Loc dfer_pop_loc(TM *tm) {
   if (tm->dsyn) {
     // Deferred bag is sync'd so we can pop
     u32 dpid = 1u - tm->dpid;
     if (tm->dput[dpid] > 0) {
       tm->dput[dpid] -= 2;
-      
-      #if defined(DEBUG)
-      if (dfer_debug) {
-        fprintf(stderr, "%u popping from deferred %u @ %u\n", tm->tid,
-                dpid, tm->dput[dpid]);
-      }
-      #endif
-      //++noflw;
-      
       return dfer_ini(tm->tid, dpid) + tm->dput[dpid];
     } else {
       tm->dsyn = false;
@@ -750,22 +587,10 @@ static Loc redex_pop_loc(TM* tm) {
     if (tm->sid == tm->tid) {
       tm->bput -= 2;
     }
-
-    #if defined(DEBUG)
-    if (bty_debug) {
-      fprintf(stderr, "%u popping from booty bag @ %u\n", tm->tid, tm->spop);
-    }
-    #endif
-
     return bbag_ini(tm->sid) + tm->spop;
   } else if (tm->rput > 0) {
     // Pop from RBAG
     tm->rput -= 2;
-
-    #if 0 && defined(DEBUG)
-    fprintf(stderr, "%u popping from RBAG @ %u\n", tm->tid, tm->rput);
-    #endif
-
     return rbag_ini(tm->tid) + tm->rput;
   } else if (tm->duse) {
     // Finally, try a flip & sync deferred bag with *any* elems
@@ -801,10 +626,6 @@ void hvm_init() {
   fprintf(stderr, "DFER_INI = %u\n", DFER_INI);
   fprintf(stderr, "DFER_LEN = %" PRIu64 "\n", DFER_LEN);
   #endif
-
-  #ifdef DEBUG
-  signal(SIGSEGV, segv_handler);
-  #endif
 }
 
 void hvm_free() {
@@ -813,6 +634,9 @@ void hvm_free() {
     BUFF = NULL;
   }
   free_static_data();
+}
+
+void handle_failure() {
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -1441,8 +1265,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
-  //bool processed = true;
-
   switch (neg_tag) {
   case APP:
     switch (pos_tag) {
@@ -1462,7 +1284,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       interact_appsup(tm, neg_loc, pos_loc);
       break;
     default:
-      //processed = false;
       break;
     }
     break;
@@ -1484,7 +1305,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      //processed = false;
       break;
     }
     break;
@@ -1506,7 +1326,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      //processed = false;
       break;
     }
     break;
@@ -1530,7 +1349,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       interact_dupsup(tm, neg_loc, pos_loc);
       break;
     default:
-      //processed = false;
       break;
     }
     break;
@@ -1552,7 +1370,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      //processed = false;
       break;
     }
     break;
@@ -1568,43 +1385,15 @@ static bool interact(TM *tm, Term neg, Term pos) {
     case U32:
     case REF:
     default:
-      //processed = false;
       break;
     }
     break;
   default:
-    //processed = false;
     break;
   }
   tm->itrs += 1;
-
-  #if defined(DEBUG)
-  if (!processed) {
-    unprocessed_itrs[neg_tag * 16 + pos_tag] = 1;
-    return false;
-  }
-  #endif
-
   return true;
 }
-
-#ifdef DEBUG
-static void show_unprocessed_itrs() {
-  for (u32 i = 17; i <= 255; i++) {
-    u32 pos_tag = i % 16;
-    if (pos_tag < 1) continue;
-    u32 neg_tag = i / 16;
-    bool hdr = true;
-    if (unprocessed_itrs[neg_tag*16 + pos_tag]) {
-      if (hdr) {
-        fprintf(stderr, "Unprocesed itrs:\n");
-        hdr = false;
-      }
-      fprintf(stderr, "%s%s\n", tag_to_str(neg_tag), tag_to_str(pos_tag));
-    }
-  }
-}
-#endif
 
 static bool sequential_step(TM* tm) {
   Loc loc = redex_pop_loc(tm);
@@ -1634,42 +1423,6 @@ static bool set_busy(bool was_busy) {
   return true;
 }
 
-#if 0
-    for (u64 i = 0; i < PCOR; i++) {
-      u32 vic = (tm->pvic - 1) % TPC;
-      if ((tm->smsk & (1 << vic)) == 0) {
-        tm->pvic = vic;
-        return tm->pvic;
-      }
-      tm->smsk |= (1 << vic);
-    }
-  }
-  tm->smsk &= ~(PCOR-1);
-  tm->pvic = tm->tid % PCOR;
-
-  // Fallback to ECore
-  //tm->evic = ((tm->evic - 1) % (TPC - PCOR)) + PCOR;
-  /*
-  if ((tm->smsk & ((TPC-PCOR-1) << PCOR)) == ((TPC-PCOR-1) << PCOR)) {
-    tm->smsk &= ~((TPC-PCOR-1) << (PCOR));
-  }
-  */
-  for (u64 i = 0; i < (TPC - PCOR); i++) {
-    u32 vic = ((tm->evic - 1) % (TPC - PCOR)) + PCOR;
-    if ((tm->smsk & (1 << vic)) == 0) {
-      tm->evic = vic;
-      return tm->evic;
-    }
-    tm->smsk |= (1 << vic);
-  }
-  tm->smsk &= ~((TPC-PCOR-1) << (PCOR));
-  tm->evic = (tm->tid % (TPC - PCOR)) + PCOR;
-
-  // We've failed all stealing from all threads consecutively - fallback to pvic
-
-  return tm->pvic;
-#endif
-
 static u32 get_victim(TM* tm) {
 #ifdef __APPLE__
   // PCore bias: if we didn't fail last attempt, or we failed on ECore, try PCore
@@ -1695,14 +1448,9 @@ static bool try_steal(TM *tm) {
       // We're holding it, so we can "steal" (from) it without atomics
       tm->spop = tm->bput;
       tm->sid = tm->tid;
-
-      #if 0 || defined(DEBUG)
-      if (bty_debug) {
-        fprintf(stderr, "%u stealing from own held bbag!\n", tm->tid);
-      }
-      #endif
       return true;
     } else {
+      // We dropped it - try to pick it up
       if (bbag_pickup(tm)) {
         return true;
       }
@@ -1712,24 +1460,10 @@ static bool try_steal(TM *tm) {
   // another thread's full bag
   u32 vic = get_victim(tm);
   if (bbag_steal(tm, vic)) {
-    tm->sgud += 1;
-    
-    if (tm->lvic < TPC) {
-      if (tm->scnt > tm->smax) {
-        tm->smax = tm->scnt;
-      }
-      tm->stot += tm->scnt;
-      tm->scnt = 0;
-    }
-
     tm->lvic = TPC;
     return true;
   }
-  tm->sbad += 1;
   tm->lvic = vic;
-
-  tm->scnt += 1;
-
   return false;
 }
 
@@ -1776,7 +1510,7 @@ static void bind_core(int tid) {
 #endif // __APPLE__
 
 static void* thread_func(void* arg) {
-  thread_id = (u64)arg;
+  int thread_id = (u64)arg;
 
 #ifdef __APPLE__
   bind_core(thread_id);
@@ -1823,18 +1557,13 @@ static void* thread_func(void* arg) {
         if (!busy && timeout(tick))
           break;
       }
-      #if 1
-      else if (tm->sgud == 1) {
-        fst_steal = tick;
-      }
-      #endif
     }
   }
 
   #ifdef SUMMARY
-  fprintf(stderr, "t%u itrs %" PRIu64 ", steals gud %u bad %u fst %" PRIu64 " max %hu tot %hu\n",
-          tm->tid, tm->itrs, tm->sgud, tm->sbad, fst_steal, tm->smax, tm->stot);
+  fprintf(stderr, "t%u itrs %" PRIu64 "\n", tm->tid, tm->itrs);
   #endif
+
   return NULL;
 }
 
@@ -1847,10 +1576,6 @@ static void parallel_normalize() {
   for (u64 i = 0; i < TPC; i++) {
     pthread_join(threads[i], NULL);
   }
-
-  #ifdef DEBUG
-  show_unprocessed_itrs();
-  #endif
 }
 
 Term normalize(Term term) {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <unistd.h>
 
-//#define OFLOW
 //#define DEBUG
 //#define MEMLOG
 //#define VOIDTEST
@@ -59,6 +58,18 @@ __asm__(
     //"   isb\n"
     "   mrs x0, cntvct_el0\n"
     "   ret\n"
+);
+
+extern void dmb_ishst(void);
+__asm__(
+    ".global dmb_ishst\n"
+    ".global _dmb_ishst\n"
+    //".type dmb_ishst, @function\n"
+    "_dmb_ishst:\n"
+    "dmb_ishst:\n"
+    "    dmb ishst\n"
+    "    ret\n"
+    //".size dmb_ishst, .-dmb_ishst\n"
 );
 #endif
 
@@ -141,14 +152,15 @@ enum : u64 {
   ZERO = 0,
 
   // Threads per CPU
-  TPC = 4,
+  TPC = 10,
 
-  // Number of terms *per thread* for each overflow bag. There are two of them,
-  // and they (currently) borrow space from each thread's RBAG space.
-  OFLW_LEN = 1 << 15,
+  // Maximum number of terms *per thread* for each overflow bag.
+  OFLW_LEN = 256,
+  // When overflow bag gets this big, a memory sync occurs.
+  OFLW_SYNC = 32,
 
   // Includes overflow and BBAG
-  RBAG_RANDO = (1 << 21) * TPC * sizeof(Pair),
+  RBAG_RANDO = 8192 * TPC * sizeof(Pair),
 
   //////////////////////////
   // Choose a RBAG size here
@@ -157,7 +169,7 @@ enum : u64 {
 };
 
 enum : u32 {
-  // Must of these must be 16-byte aligned (even).
+  // Most of these must be 16-byte aligned (even numbers).
 
   // Final calculated RBAG index
   RBAG = ((HEAP_SIZ - RBAG_SIZ) / sizeof(Term)) & ~1ULL,
@@ -224,9 +236,7 @@ typedef struct TM {
   u32 sgud;  // successful steal count
   u32 sbad;  // failed steal count
 
-#ifdef OFLOW
   Loc oput[2]; // next oflw bag push indices
-#endif
   
 #ifdef MEMLOG
   u32 mput;
@@ -237,13 +247,12 @@ typedef struct TM {
 #endif
 
   bool buse; // can use booty bag
-  bool bhld; // booty bag ctrl word is HELD
+  bool bhld; // when we KNOW booty bag ctrl word is HELD
+             // (in some cases it may be HELD but we don't know)
 
-#ifdef OFLOW
   u8   opid; // oput idx we are pushing into
   bool ouse; // can use overflow
   bool osyn; // overflow is sync'd
-#endif
 
   u64 itrs;  // interaction count
 } TM;
@@ -252,11 +261,10 @@ static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
 
 // Booty bag control word values
 enum : u32 {
-  HELD = 1,    // held by owner
-  DROPPED = 2, // dropped by owner. can be picked back up by owner or stolen
-               // by another thread
+  HELD = 1,    // held by owner, or "tossed" by another thread
+  DROPPED = 2, // dropped by owner. can be picked back up by owner
+               // or stolen by another thread
   STOLEN = 3,  // stolen by another thread
-  TOSSED = 4   // emptied by another thread. thief's version of DROPPED.
 };
 
 typedef struct BB {
@@ -562,13 +570,11 @@ TM *tm_new(u64 tid) {
   tm->bhld = true;
   tm->buse = false;
 
-#ifdef OFLOW
   tm->oput[0] = 0;
   tm->oput[1] = 0;
   tm->opid = 0;
   tm->ouse = false;
   tm->osyn = false;
-#endif
 
   return tm;
 }
@@ -772,7 +778,6 @@ static void bbag_set(u32 tid, u32 val, memory_order order) {
   atomic_store_explicit(&bbs[tid].ctrl, val, order);
 }
 
-__attribute__((unused))
 static u32 bbag_get(u32 tid) {
   return atomic_load_explicit(&bbs[tid].ctrl, memory_order_relaxed);
 }
@@ -792,7 +797,7 @@ static void bbag_drop(TM *tm) {
 
 // attempt to recover a tossed (stolen, and emptied) booty bag
 static bool bbag_recover(TM *tm) {
-  bool held = bbag_compare_swap(tm->tid, TOSSED, HELD, memory_order_relaxed);
+  bool held = bbag_get(tm->tid) == HELD;
   if (held) {
     tm->bhld = true;
     tm->bput = 0;
@@ -850,8 +855,7 @@ static void bbag_toss(TM *tm) {
   }
   #endif
 
-  // TODO: compare_exchange from STOLEN for added safety
-  bbag_set(tm->sid, TOSSED, memory_order_relaxed);
+  bbag_set(tm->sid, HELD, memory_order_relaxed);
   tm->sid = TPC;
 }
 
@@ -867,7 +871,6 @@ static Loc rnod_ini(u32 tid) {
   return tid * NODE_LEN;
 }
 
-#ifdef OFLOW
 static Loc oflw_offset(u32 oidx) {
   return OFLW_INI + OFLW_LEN * oidx;
 }
@@ -879,7 +882,6 @@ static Loc oflw_ini(u32 tid, u32 oidx) {
 static bool oflw_empty(TM *tm) {
   return (tm->oput[0] == 0) && (tm->oput[1] == 0);
 }  
-#endif
 
 // Allocator
 // ---------
@@ -889,12 +891,12 @@ static u64 align(u64 align, u64 val) {
 }
 
 static Loc node_alloc(TM *tm, u32 cnt) {
-#ifdef DEBUG
+  #ifdef DEBUG
   if (mop_debug) {
     fprintf(stderr, "%u node alloc cnt: %u, nput: %u\n", tm->tid, cnt,
             tm->nput);
   }
-#endif
+  #endif
 
   if (tm->nput + cnt >= NODE_LEN) {
     fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
@@ -908,7 +910,6 @@ static Loc node_alloc(TM *tm, u32 cnt) {
 }
 
 static Loc get_push_offset(TM *tm, bool force_oflw) {
-#ifdef OFLOW
   if (force_oflw && tm->ouse) {
     #if defined(DEBUG)
     if (oflw_debug) {
@@ -921,7 +922,6 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
     tm->oput[tm->opid] += 2;
     return oflw_offset(tm->opid) + oput;
   }
-#endif
 
   // Only push to booty bag if we aren't stealing
   if (tm->buse && tm->bhld && !bbag_full(tm) && (tm->sid == TPC)) {
@@ -947,13 +947,13 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
 }
 
 static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
-#ifdef VOIDTEST
+  #ifdef VOIDTEST
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d rbag_push: void term\n", thread_id);
     exit_stacktrace();
     //    mlog_exit();
   }
-#endif
+  #endif
 
   Loc off = get_push_offset(tm, force_oflw);
   Loc loc = bbag_ini(tm->tid) + off;
@@ -962,17 +962,7 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
 
   // TODO: adjust_put_idx(tm, off);
 
-#ifdef OFLOW
-  if (off >= OFLW_INI) {
-    // pushed to overflow
-    if (tm->oput[tm->opid] >= OFLW_LEN-1) {
-      fprintf(stderr, "%u overflow %u space exhausted @ %u\n", tm->tid,
-              tm->opid, tm->oput[tm->opid]);
-      exit(1);
-    }
-  } else
-#endif
-#ifdef DEBUG
+  #ifdef DEBUG
   if (off > BBAG_LEN) {
     // pushed to RBAG
     if (tm->rput >= RPUT_MAX-1) {
@@ -980,35 +970,52 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
       exit(1);
     }
   }
-#endif
+  #endif
 }
 
 _Thread_local u64 noflw = 0;
 
-static Loc redex_pop_loc(TM* tm) {
-#ifdef OFLOW
-  // Must check overflow bag first when sync'd
-  if (tm->ouse) {
-    if (tm->osyn) {
-      // Overflow is sync'd so we can pop
-      u32 oidx = 1u - tm->opid;
-      if (tm->oput[oidx] > 0) {
-        tm->oput[oidx] -= 2;
-        
-        #if defined(DEBUG)
-        if (oflw_debug) {
-          fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
-                  oidx, tm->oput[oidx]);
-        }
-        #endif
-
-        ++noflw;
-        
-        return oflw_ini(tm->tid, oidx) + tm->oput[oidx];
+static Loc oflw_pop_loc(TM *tm) {
+  if (tm->osyn) {
+    // Overflow is sync'd so we can pop
+    u32 oidx = 1u - tm->opid;
+    if (tm->oput[oidx] > 0) {
+      tm->oput[oidx] -= 2;
+      
+      #if defined(DEBUG)
+      if (oflw_debug) {
+        fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
+                oidx, tm->oput[oidx]);
       }
+      #endif
+      ++noflw;
+      
+      return oflw_ini(tm->tid, oidx) + tm->oput[oidx];
+    } else {
+      tm->osyn = false;
     }
   }
-#endif
+  return 0;
+}
+
+static void oflw_sync(TM *tm) {
+  dmb_ishst();
+  tm->opid = 1u - tm->opid;
+  tm->osyn = true;
+}
+
+static Loc redex_pop_loc(TM* tm) {
+  // Must check overflow bag first when sync'd
+  if (tm->ouse) {
+    Loc loc = oflw_pop_loc(tm);
+    if (loc > 0) return loc;
+
+    if (tm->oput[tm->opid] > OFLW_SYNC) {
+      oflw_sync(tm);
+      Loc loc = oflw_pop_loc(tm);
+      if (loc > 0) return loc;
+    }
+  }
     
   if ((tm->sid < TPC) && (tm->spop > 0)) {
     // Pop from stolen non-empty booty bag - but we could have 'stolen' our
@@ -1036,10 +1043,15 @@ static Loc redex_pop_loc(TM* tm) {
     #endif
 
     return rbag_ini(tm->tid) + tm->rput;
-  } else {
-    // Steal from someone else
-    return 0;
+  } else if (tm->ouse) {
+    if (tm->oput[tm->opid] > 0) {
+      oflw_sync(tm);
+      Loc loc = oflw_pop_loc(tm);
+      if (loc > 0) return loc;
+    }
   }
+  // Steal from someone else
+  return 0;
 }
 
 // FFI functions
@@ -1062,17 +1074,15 @@ void hvm_init() {
   fprintf(stderr, "RBAG_LEN = %u\n", RBAG_LEN);
   fprintf(stderr, "NODE_LEN = %u\n", NODE_LEN);
   fprintf(stderr, "BBAG_LEN = %u\n", BBAG_LEN);
-#ifdef OFLOW
   fprintf(stderr, "OFLW_INI = %u\n", OFLW_INI);
   fprintf(stderr, "OFLW_LEN = %" PRIu64 "\n", OFLW_LEN);
-#endif
   #endif
 
   signal(SIGSEGV, segv_handler);
 
-#ifdef MEMLOG
+  #ifdef MEMLOG
   mlog_init();
-#endif
+  #endif
 }
 
 void hvm_free() {
@@ -1082,9 +1092,9 @@ void hvm_free() {
   }
   free_static_data();
 
-#ifdef MEMLOG
+  #ifdef MEMLOG
   mlog_free();
-#endif
+  #endif
 }
 
 Loc ffi_alloc_node(u64 arity) {
@@ -1907,12 +1917,9 @@ static bool sequential_step(TM* tm) {
  
 // don't allow idling if our booty bag isn't held
 // because it introduces weirdness that's easier to just ignore for now
+ __attribute__((unused))
 static bool can_idle(TM *tm) {
-  return rbag_empty(tm) && bbag_empty(tm) && tm->bhld
-#ifdef OFLOW
-    && oflw_empty(tm)
-#endif
-    ;
+  return rbag_empty(tm) && bbag_empty(tm) && tm->bhld && oflw_empty(tm);
 }
  
 static bool set_idle(bool was_busy) {
@@ -1998,156 +2005,14 @@ static bool lala_and_interact(TM *tm, Pair pair) {
   return interact(tm, pair_neg(pair), pair_pos(pair));
 }
 
-#include <sys/sysctl.h>
-#include <mach/mach.h>
-#include <mach/thread_policy.h>
-
-__attribute__((unused))
-void setup_thread_for_pcore(int thread_id) {
-    // Set high QoS first
-    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-    
-    // Then try to bind to specific P-core
-    thread_affinity_policy_data_t policy;
-    policy.affinity_tag = thread_id; // 0-3 for P-cores
-    thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
-                     (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
-}
-
- __attribute__((unused))
-void setup_thread_for_ecore(int thread_id) {
-    // Set lower QoS
-    pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
-    
-    // Bind to E-core
-    thread_affinity_policy_data_t policy;
-    policy.affinity_tag = thread_id; // 4-9 for E-cores
-    thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
-                     (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
-}
-
-#ifdef OFLOW
-struct SIMPLE_SYNC {
-  a64 requested;
-  a64 arrived;
-  a64 departed;
-  a64 generation;
-} ss;
-
- __attribute__((unused))
-static void sync_clear_requests() {
-  atomic_store_explicit(&ss.requested, ZERO, memory_order_relaxed);
-}
-
-static bool sync_requested() {
-  return atomic_load_explicit(&ss.arrived, memory_order_relaxed) > 0;
-}
-
-static _Thread_local u64 my_gen = 0;
-
-static bool sync_arrive() {
-  u64 prev_cnt = atomic_fetch_add_explicit(&ss.arrived, 1, memory_order_release);
-  if ((prev_cnt + 1) == TPC) {
-    if (oflw_debug) {
-      fprintf(stderr, "%d last to arrive @ %" PRIu64 "\n", thread_id, my_gen);
-    }
-    return true;
-  }  if (oflw_debug) {
-
-    fprintf(stderr, "%d arrived @ %" PRIu64 "\n", thread_id, my_gen);
-  }
-  return false;
-}
-
-static bool sync_wait_arrivals() {
-  return atomic_load_explicit(&ss.arrived, memory_order_relaxed) == TPC;
-}
-
-_Thread_local u32 nsync = 0;
-
-__attribute__((unused))
-static bool sync_depart() {
-  u64 prev_cnt = atomic_fetch_add_explicit(&ss.departed, 1, memory_order_relaxed);
-  if ((prev_cnt + 1) == TPC) {
-    atomic_exchange_explicit(&ss.arrived, ZERO, memory_order_acquire);
-    // exchange needed to sync with all other releases
-    // or use atomic store + thread_fence acquire
-    atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
-
-    if (oflw_debug) {
-      fprintf(stderr, "%d last to depart %" PRIu64 ", setting to gen %" PRIu64 "\n",
-              thread_id, my_gen, my_gen + 1);
-    }
-
-    my_gen += 1;
-    atomic_store_explicit(&ss.generation, my_gen, memory_order_relaxed);
-    return true;
-  } else if (oflw_debug) {
-    fprintf(stderr, "%d departed from %" PRIu64 "\n", thread_id, my_gen);
-  }
-  my_gen += 1;
-  return false;
-}
-
-static bool sync_wait_departures() {
-  // while a thread is waiting to depart, it can't process any other operations
-  // because some threads may have already departed and "published" new data that
-  // it hasn't synchronized with yet;
-  if (atomic_load_explicit(&ss.generation, memory_order_relaxed) < my_gen) {
-    return false;
-  }
-  nsync += 1;
-  atomic_thread_fence(memory_order_acquire);
-  //atomic_load_explicit(&ss.arrived, memory_order_acquire);
-  return true;
-}
-
-#define SYNC_REQ_SIZE 4096
-
-// more booty bag 'HELD' weirdness i'm trying to bicycle around. allow sync
-// sync requests if booty bag appears non-empty, if it's not held
-static bool request_sync(TM *tm) {
-  Loc oput = tm->oput[tm->opid];
-  bool req = (oput >= SYNC_REQ_SIZE) ||
-    ((oput > 0) && rbag_empty(tm) && (bbag_empty(tm) || !tm->bhld));
-  if (req) {
-    if (oflw_debug) {
-      fprintf(stderr, "%u requesting sync\n", tm->tid);
-    }
-  }
-  return req;
-}
-#endif // OFLOW
-
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
-
-  #if 0
-  bool ecore = false;
-  if (thread_id < 4) {
-    setup_thread_for_pcore(thread_id);
-  } else {
-    setup_thread_for_ecore(thread_id);
-    ecore = true;
-  }
-  #endif
-  
   TM *tm = tms[thread_id];
 
   // Wait until after injection to turn these on
   tm->buse = true;
-  //  tm->ouse = true;
-
-#ifdef OFLOW
-  // Overflow synchronization
-  // TODO: Could moving these to global to reduce code in this funciton
-  bool all_arrived = false;
-  bool syncing = false;
-#endif
+  tm->ouse = true;
   u64 do_nothing = 0;
-
-  __attribute__((unused))
-  u64 last_work_tick = 0;
 
   u64  tick = 0;
   bool busy = tm->tid == 0;
@@ -2158,105 +2023,34 @@ static void* thread_func(void* arg) {
 
     tick += 1;
 
-#if 0
-    if (busy && ((tick - last_work_tick) % 65536 == 0)) {
-      fprintf(stderr, "%u busy doing nothing syncing %u osyn %u bbag %u bhld %u stolen %u rbag %u oflw %u oflw_other %u\n",
-              tm->tid, (u32) syncing, (u32)tm->osyn, tm->bput, (u32) tm->bhld, (u32)(tm->sid < TPC),
-              tm->rput, tm->oput[tm->opid], tm->oput[1-tm->opid]);
+    // Try to recover stolen and emptied booty bag
+    if (!tm->bhld) {
+      bbag_recover(tm);
     }
-#endif
-
-#ifdef OFLOW
-    if (tm->ouse) {
-      if (!syncing) {
-        syncing = sync_requested();
-        if (!syncing) {
-          if (request_sync(tm)) {
-            all_arrived = sync_arrive();
-            syncing = true;
-
-            if (oflw_debug && all_arrived) {
-              fprintf(stderr, "%u last to arrive upon simultaneous request @ %" PRIu64 "\n",
-                      tm->tid, my_gen);
-            }
-          }
-        } else {
-          all_arrived = sync_arrive();
-          syncing = true;
-        }
-        if (syncing) {
-          tm->opid = 1 - tm->opid;
-          tm->osyn = false;
-        }
-      }
-      if (syncing) {
-        if (!all_arrived) {
-          all_arrived = sync_wait_arrivals();
-
-          if (all_arrived && oflw_debug) {
-            fprintf(stderr, "%u all arrived @ %" PRIu64 "\n", tm->tid, my_gen);
-          }
-        }
-        if (all_arrived) {
-          bool all_departed = sync_depart();
-          while (!all_departed) {
-            all_departed = sync_wait_departures();
-            sched_yield();
-          }
-          syncing = false;
-          all_arrived = false;
-          tm->osyn = true;
-
-          if (oflw_debug) {
-            fprintf(stderr, "%u synched @ %" PRIu64 ", can take from overflow %u len %u\n",
-                    tm->tid, my_gen, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
-          }
-        }
-      }
-    }
-#endif
-
-      // Try to recover stolen and emptied booty bag
-      if (!tm->bhld) {
-        bbag_recover(tm);
-      }
-
-    // much hax
-#if 0
-    u32 oidx = 1u-tm->opid;
-    u32 oput = tm->oput[oidx];
-#endif
 
     Loc loc = redex_pop_loc(tm);
     if (loc) {
-      last_work_tick = 0;
-
       busy = set_busy(busy);
       
       Pair pair = take_pair(loc);
-      if (!lala_and_interact(tm, pair)) {
-#if 0
-        Tag neg_tag = term_tag(pair_neg(pair));
-        Tag pos_tag = term_tag(pair_pos(pair));
-        if (!((neg_tag == ERA) && (pos_tag == REF))) {
-          from_bty = spop > tm->spop;
-          bool oflw = oput > tm->oput[1-tm->opid];
-          fprintf(stderr, "%u uprocessed %s%s bty %u oflw %u\n", tm->tid,
-                  tag_to_str(neg_tag), tag_to_str(pos_tag),
-                  (u32)from_bty, (u32)oflw);
-        }
-#endif
-      }
+      lala_and_interact(tm, pair);
 
       if (tm->bhld && (tm->sid == TPC) && bbag_full(tm)) {
         // We're holding a full, non-stolen booty bag. Consider dropping it.
-        if (!rbag_empty(tm)) { //|| !oflw_empty(tm)) {
+        if (!rbag_empty(tm) || !oflw_empty(tm)) {
           bbag_drop(tm);
         }
       }
     } else {
       do_nothing += 1;
-
+#if 0
+      busy = set_idle(busy);
+      if (!try_steal(tm)) {
+        sched_yield();
+        if (timeout(tick))
+          break;
+      }
+#else
       if (busy && can_idle(tm)) {
         busy = set_idle(busy);
       }
@@ -2265,6 +2059,7 @@ static void* thread_func(void* arg) {
         if (timeout(tick))
           break;
       }
+#endif
     }
   }
 
@@ -2281,17 +2076,9 @@ static void* thread_func(void* arg) {
 static void parallel_normalize() {
   atomic_store_explicit(&net.idle, TPC-1, memory_order_relaxed);
 
-#ifdef OFLOW
-  atomic_store_explicit(&ss.requested, ZERO, memory_order_relaxed);
-  atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
-  atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
-  atomic_store_explicit(&ss.generation, ZERO, memory_order_relaxed);
-#endif
-
   for (u64 i = 0; i < TPC; i++) {
-    /*int rc = */pthread_create(&threads[i], NULL, thread_func, (void*)i);
+    pthread_create(&threads[i], NULL, thread_func, (void*)i);
   }
-
   for (u64 i = 0; i < TPC; i++) {
     pthread_join(threads[i], NULL);
   }
@@ -2374,7 +2161,7 @@ static char *bty_ctrl_str(u32 ctrl) {
   case HELD:    return "HELD";
   case DROPPED: return "DROPPED";
   case STOLEN:  return "STOLEN";
-  case TOSSED:  return "TOSSED";
+  //case TOSSED:  return "TOSSED";
   default:      return "???";
   }
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -184,13 +184,16 @@ typedef struct TM {
   u32 btid; // tid from which bbag was stolen
   u32 sgud; // successful steals
   u32 sbad; // failed steals
+
+  // debugging
+  u32 mput;
+  u32 itid;
+  u32 i1_tag;
+  u32 i2_tag;
+
   u64 itrs; // interaction count
   bool buse; // use booty bag
   bool muse; // use mlog
-  u32 mput;
-  #if 0
-  u32 mbuf[MBUF_SIZ];
-  #endif
 } TM;
 
 //static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
@@ -222,8 +225,9 @@ void dump_buff(TM *tm);
 #define TERMSTR_BUFSIZ 128
 
 static const char* term_str(char* buf, Term term);
+Tag term_tag(Term term) { return term & 0xFF; }
 
-//#define MEMLOG // comment out to disable
+#define MEMLOG // comment out to disable
 
 #ifdef MEMLOG
 
@@ -236,13 +240,13 @@ static const char* term_str(char* buf, Term term);
 static u64 *MEMBUFF = NULL;
 //static a64 MLOG_END = 0;
 enum : u32 {
-  MLOG_SIZ = (1U << 28) * sizeof(u64),
+  MLOG_SIZ = (1U << 26) * sizeof(u64),
   MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
 };
 
 //static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, 0, loc, t1, t2, 0)
-#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, 0, loc, t1, t2, lvl)
+#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, loc, t1, t2, 0)
+#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, loc, t1, t2, lvl)
 #else
 #define MLOG(mop, loc, t1, t2)
 #define MLOG_LVL(mop, loc, lvl, t1, t2)
@@ -253,8 +257,6 @@ static void mlog_init() {
   if (MEMBUFF == NULL) {
     MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_SIZ);
   }
-  //memset(MEMBUFF, 0, MLOG_MAX * sizeof(u32));
-  //MLOG_END = 0;
 }
 
 static void mlog_free() {
@@ -264,9 +266,13 @@ static void mlog_free() {
   }
 }
 
-// lvl: 5, op:3, loc: 7, tid: 4, sid: 4
-static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl) {
-  u64 hi = (lvl << 18) | ((mop & 0x7) << 15) | ((loc & 0x7F) << 8) | ((tid & 0xF) << 4) | (sid & 0xF);
+// i1_tag: 4, i2_tag: 4, lvl: 5, op:2, t1_tag: 4, t2_tag: 4, tid: 4, sid: 4
+static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl,
+                      u32 i1_tag, u32 i2_tag, u32 t1_tag, u32 t2_tag) {
+  u64 hi = (i1_tag << 27) | ((i2_tag & 0xF) << 23) |
+    ((lvl & 0x1F) << 18) | ((mop & 0x3) << 16) |
+    ((t1_tag & 0xF) << 12) | ((t2_tag & 0xF) << 8) |
+    ((tid & 0xF) << 4) | (sid & 0xF);
   return hi << 32 | loc;
 }
 
@@ -274,19 +280,29 @@ static u32 mlog_hi(u64 e) {
   return e >> 32;
 }
 
+static u32 mlog_i1_tag(u64 e) {
+  return (mlog_hi(e) >> 27);
+}
+
+static u32 mlog_i2_tag(u64 e) {
+  return (mlog_hi(e) >> 23) & 0xF;
+}
+
 static u32 mlog_lvl(u64 e) {
-  return mlog_hi(e) >> 18;
+  return (mlog_hi(e) >> 18) & 0x1F;
 }
 
 static u32 mlog_mop(u64 e) {
-  return (mlog_hi(e) >> 15) & 0x7;
+  return (mlog_hi(e) >> 16) & 0x3;
 }
 
-/*
-static u32 mlog_loc(u64 e) {
-  return (mlog_hi(e) >> 8) & 0x7F;
+static u32 mlog_t1_tag(u64 e) {
+  return (mlog_hi(e) >> 12) & 0xF;
 }
-*/
+
+static u32 mlog_t2_tag(u64 e) {
+  return (mlog_hi(e) >> 8) & 0xF;
+}
 
 static u32 mlog_tid(u64 e) {
   return (mlog_hi(e) >> 4) & 0xF;
@@ -330,9 +346,11 @@ static void mlog_dump(const char* fn) {
       char buf1[TERMSTR_BUFSIZ];
       char buf2[TERMSTR_BUFSIZ];
       */
-      fprintf(fp, "%" PRIu64 ",%u,%s,%u,%u\n", cnt, mlog_tid(e), mop_str(mlog_mop(e)),
-              /*mlog_sid(e),*/ mlog_lvl(e), mlog_loc(e));
-      //, term_str(buf1, t1), term_str(buf2, t2));
+      fprintf(fp, "%" PRIu64 ",%u,%s%s,%u,%s,%u,%s,%s,%u\n", cnt, mlog_tid(e),
+              tag_to_str(mlog_i1_tag(e)), tag_to_str(mlog_i2_tag(e)),
+              mlog_sid(e), mop_str(mlog_mop(e)), mlog_lvl(e),
+              tag_to_str(mlog_t1_tag(e)), tag_to_str(mlog_t2_tag(e)),
+              mlog_loc(e));
     }
   }
   fclose(fp);
@@ -353,7 +371,7 @@ __asm__(
 );
 #endif
 
-static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2, u32 lvl) {
+static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
   static bool at_end = false;
 
   TM *tm = tms[tid];
@@ -361,7 +379,8 @@ static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2, u32 lvl) 
     u32 pos = tid * MLOG_LEN + tm->mput;
 
     MEMBUFF[pos] = read_cntvct();
-    MEMBUFF[pos+1] = mlog_entry(tid, mop, sid, loc, lvl);
+    MEMBUFF[pos+1] = mlog_entry(tid, mop, tm->itid, loc, lvl, tm->i1_tag,
+                                tm->i2_tag, term_tag(t1), term_tag(t2));
 
     /*
     *(Term*)&MEMBUFF[end] = t1;
@@ -376,29 +395,6 @@ static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2, u32 lvl) 
   }
 }
 
-/*
-static void mlog_lvl(u32 tid, u32 mop, u32 sid, u32 lvl, Loc loc, Term t1, Term t2) {
-  static bool at_end = false;
-
-  // ugly but acceptable load-test-add pattern for debug logging.
-  u32 end = atomic_load(&MLOG_END);
-  if (end + 5 < MLOG_MAX) {
-    end = atomic_fetch_add(&MLOG_END, 5UL);
-    if (end < MLOG_MAX) {
-      MEMBUFF[end] = mlog_entry(tid, mop, sid, loc);
-      end += 1;
-      *(Term*)&MEMBUFF[end] = t1;
-      end += 2;
-      *(Term*)&MEMBUFF[end] = t2;
-      return;
-    }
-  }
-  if (!at_end) {
-    fprintf(stderr, "end of MLOG reached\n");
-    at_end = true;
-  }
-}
-*/
 #endif // MEMLOG
 
 void mlog_exit() {
@@ -487,8 +483,6 @@ static Term pair_neg(Pair pair) {
 Term term_new(Tag tag, Lab lab, Loc loc) {
   return ((Term)loc << 32) | ((Term)lab << 8) | tag;
 }
-
-Tag term_tag(Term term) { return term & 0xFF; }
 
 Lab term_lab(Term term) { return (term >> 8) & 0xFFFFFF; }
 
@@ -952,13 +946,6 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     Pair pair = *(Pair*)&rbag[i];
     Loc loc = rbag_push(tm, term_offset_loc(pair_neg(pair), offset),
                         term_offset_loc(pair_pos(pair), offset));
-    #if 0
-    if (def_idx == 5) {
-      if (tm->mput < MBUF_SIZ) {
-        tm->mbuf[tm->mput++] = loc;
-      }
-    }
-    #endif
   }
 
   return root;
@@ -1752,8 +1739,6 @@ static void* thread_func(void* arg) {
   // TODO: this could be a global net flag i think.
   tm->buse = true;
 
-  //sync_threads();
-
   u32  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
@@ -1765,47 +1750,23 @@ static void* thread_func(void* arg) {
 
       Pair pair = take_pair(loc);
 
-      //bbag_maybe_empty(tm, prev_bpop);
+      // Debugging
+      tm->i1_tag = term_tag(pair_neg(pair));
+      tm->i2_tag = term_tag(pair_pos(pair));
+      tm->itid = bty ? tm->btid : tm->tid;
 
-      if (bty) {
-        //MLOG(MOP_LOAD, tm->btid, tm->bpop, pair_neg(pair), pair_pos(pair));
-
-        if (1 && bty_debug) {
-          char buf[TERMSTR_BUFSIZ];
-          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
-          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
-        }
-
-        if (tm->bpop == 0) {
-          if (tm->btid != tm->tid) {
-            // Mark stolen booty bag empty
-            bbag_set(tm->btid, EMPTY, memory_order_relaxed);
-          
-            if (0 && bty_debug) {
-              fprintf(stderr, "%u finished popping from t%u's booty bag\n",
-                      tm->tid, tm->btid);
-            }
-          }
-          else {
-            if (0 && bty_debug) {
-              fprintf(stderr, "%u finished popping from own booty bag\n", tm->tid);
-            }
-          }
-        }
-      } else {
-        //MLOG(MOP_LOAD, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
+      if (bty && (tm->bpop == 0) && (tm->btid != tm->tid)) {
+        // Mark stolen booty bag empty
+        bbag_set(tm->btid, EMPTY, memory_order_relaxed);
       }
 
-      if (pair != 0) {
-        interact(tm, pair_neg(pair), pair_pos(pair));
-      }
+      interact(tm, pair_neg(pair), pair_pos(pair));
     } else {
       busy = set_idle(busy);
 
       if (try_steal(tm)) continue;
 
       sched_yield();
-      //usleep(1);
 
       if (check_timeout(tick)) break;
     }
@@ -1818,16 +1779,6 @@ static void* thread_func(void* arg) {
     fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, bpop: %u, steals: %u good %u bad\n",
             tm->tid, tm->itrs, tm->rput, tm->bput, tm->bpop, tm->sgud, tm->sbad);
   }
-
-  //if (thd_debug) {
-  //  fprintf(stderr, "%u before sync...\n", tm->tid);
-  //}
-
-  // sync_threads();
-
-  //if (thd_debug) {
-  //  fprintf(stderr, "%u after sync done\n", tm->tid);
-  //}
 
   return NULL;
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <unistd.h>
 
+//#define SUMMARY
+
 //#define DEBUG
 //#define MEMLOG
 //#define VOIDTEST
@@ -48,14 +50,12 @@ void segv_handler(int sig) {
 
 #ifdef __APPLE__
 // Use explicit file-scope assembly to prevent compiler from optimizing out
-
 extern uint64_t read_cntvct(void);
 __asm__(
     ".global _read_cntvct\n"
     ".global read_cntvct\n"
     "_read_cntvct:\n"
     "read_cntvct:\n"
-    //"   isb\n"
     "   mrs x0, cntvct_el0\n"
     "   ret\n"
 );
@@ -64,12 +64,10 @@ extern void dmb_ishst(void);
 __asm__(
     ".global dmb_ishst\n"
     ".global _dmb_ishst\n"
-    //".type dmb_ishst, @function\n"
     "_dmb_ishst:\n"
     "dmb_ishst:\n"
     "    dmb ishst\n"
     "    ret\n"
-    //".size dmb_ishst, .-dmb_ishst\n"
 );
 #endif
 
@@ -117,7 +115,6 @@ typedef float        f32;
 typedef int64_t      i64;
 typedef uint64_t     u64;
 typedef _Atomic(u64) a64;
-// NOTE typedef alignment is gcc/clang specific
 typedef unsigned __int128 u128 __attribute__((aligned(16)));
 
 typedef u8   Tag;  //  8 bits
@@ -154,17 +151,15 @@ enum : u64 {
   // Threads per CPU
   TPC = 10,
 
-  // Maximum number of terms *per thread* for each overflow bag.
+  // Overflow bag terms per thread (there are 2 bags)
   OFLW_LEN = 256,
-  // When overflow bag gets this big, a memory sync occurs.
+  // When overflow bag gets this big, a memory sync occurs
   OFLW_SYNC = 32,
 
   // Includes overflow and BBAG
   RBAG_RANDO = 8192 * TPC * sizeof(Pair),
 
-  //////////////////////////
-  // Choose a RBAG size here
-  //////////////////////////
+  // Used in other calculations below
   RBAG_SIZ = RBAG_RANDO,
 };
 
@@ -174,14 +169,14 @@ enum : u32 {
   // Final calculated RBAG index
   RBAG = ((HEAP_SIZ - RBAG_SIZ) / sizeof(Term)) & ~1ULL,
 
-  // Calculate RBAG_LEN and NODE_LEN: number of terms *per thread*
+  // Calculate RBAG_LEN and NODE_LEN as terms per thread
   RBAG_LEN = (RBAG_SIZ / (TPC * sizeof(Term))) & ~1ULL,
   NODE_LEN = (HEAP_SIZ - RBAG_SIZ) / (TPC * sizeof(Term)),
 
-  // Booty-bag length.
+  // Booty bag terms per thread
   BBAG_LEN = 96,
 
-  // Offset in RBAG of overflow bags
+  // Starting offset in RBAG of overflow bags
   OFLW_INI = (RBAG_LEN - (OFLW_LEN * 2)) & ~1ULL,
 
   // Max terms allowed in RBAG, taking into account booty bag and overflow
@@ -274,7 +269,9 @@ typedef struct BB {
 static TM *tms[TPC];
 static BB bbs[TPC];
 static pthread_t threads[TPC];
+#ifdef DEBUG
 static uint8_t unprocessed_itrs[255] = { 0 };
+#endif
 
 static _Thread_local int thread_id = 0;
 
@@ -282,13 +279,13 @@ static _Thread_local int thread_id = 0;
 static char *tag_to_str(Tag tag);
 static char *bty_ctrl_str(u32 ctrl);
 static void dump_term(Loc loc);
-void dump_buff();
-
-#define TERMSTR_BUFSIZ 128
 
 static Term pair_pos(Pair pair);
 static Term pair_neg(Pair pair);
 static const char* term_str(char* buf, Term term);
+
+// FFI functions
+void dump_buff();
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
@@ -671,12 +668,12 @@ static const char* term_str(char* buf, Term term) {
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
-#ifdef VOIDTEST
+  #ifdef VOIDTEST
   if (got == 0) {
     fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
     mlog_exit();
   }
-#endif
+  #endif
   return got;
 }
 
@@ -687,12 +684,12 @@ Term swap(Loc loc, Term term) {
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
-#ifdef VOIDTEST
+  #ifdef VOIDTEST
   if (term == 0) {
     fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
     mlog_exit();
   }
-#endif
+  #endif
   return term;
 }
 
@@ -711,40 +708,40 @@ static Pair take_pair(Loc loc) {
   Pair pair = *(Pair*)&BUFF[loc];
   
   // Debugging
-#if defined(MEMLOG) || defined(VOIDTEST)
+  #if defined(MEMLOG) || defined(VOIDTEST)
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
-#endif
+  #endif
 
-#if defined(MEMLOG)
+  #if defined(MEMLOG)
   TM *tm = tms[thread_id];
   tm->i1_tag = term_tag(neg);
   tm->i2_tag = term_tag(pos);
   tm->itid = tm->id; // bty ? tm->sid : tm->tid;
-#endif
+  #endif
   MLOG_PAIR(MOP_LOAD, loc, pair);
 
-#ifdef VOIDTEST
+  #ifdef VOIDTEST
   //*(Pair*)&BUFF[loc] = (Pair)ZERO;
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
     exit_stacktrace();
     //    mlog_exit();
   }
-#endif
+  #endif
   
   return pair;
 }
 
 static void set_pair(Loc loc, Pair pair) {
-#ifdef VOIDTEST
+  #ifdef VOIDTEST
   Term neg = pair_neg(pair);
   Term pos = pair_pos(pair);
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d set_pair: void term\n", thread_id);
     mlog_exit();
   }
-#endif
+  #endif
 
   *((Pair*)&BUFF[loc]) = pair;
   MLOG_PAIR(MOP_STOR, loc, pair);
@@ -1078,7 +1075,9 @@ void hvm_init() {
   fprintf(stderr, "OFLW_LEN = %" PRIu64 "\n", OFLW_LEN);
   #endif
 
+  #ifdef DEBUG
   signal(SIGSEGV, segv_handler);
+  #endif
 
   #ifdef MEMLOG
   mlog_init();
@@ -1109,7 +1108,12 @@ void ffi_rbag_push(Term neg, Term pos) {
 }
 
 u64 inc_itr() {
-  return atomic_load(&net.itrs);
+  u64 itrs = 0;
+  for (u32 i = 0; i < TPC; i++) {
+    itrs += tms[i]->itrs;
+  }
+  return itrs;
+  //return atomic_load(&net.itrs);
 } 
 
 Loc ffi_rbag_ini() {
@@ -1123,7 +1127,12 @@ Loc ffi_rbag_end() {
 }
 
 Loc ffi_rnod_end() {
-  return atomic_load(&net.nods);
+  u64 nods = 0;
+  for (u32 i = 0; i < TPC; i++) {
+    nods += tms[i]->nput;
+  }
+  return nods;
+  //return atomic_load(&net.nods);
 }
 
 // Moves the global buffer and redex bag into a new def and resets
@@ -1154,7 +1163,7 @@ void def_new(char *name) {
       .rbag_len = rbag_cnt,
   };
 
-  if (def.nodes == NULL || def.rbag == NULL) {
+  if ((def.nodes == NULL) || (def.rbag == NULL)) {
     fprintf(stderr, "DEF memory allocation failed\n");
     exit(1);
   }
@@ -1165,11 +1174,11 @@ void def_new(char *name) {
   memcpy(def.nodes, nodes, sizeof(Term) * def.nodes_len);
   memcpy(def.rbag, rbag, sizeof(Term) * def.rbag_len);
 
-#if 0
+  #if 0
   printf("NEW DEF '%s':\n", def.name);
   dump_buff();
   printf("\n");
-#endif
+  #endif
 
   memset(BUFF, 0, sizeof(Term) * def.nodes_len);
   memset(rbag, 0, sizeof(Term) * def.rbag_len);
@@ -1260,21 +1269,28 @@ static inline void move(TM *tm, Loc neg_loc, Term pos) {
 }
 
 // Interactions
-static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
-  Term arg = take(port(1, a_loc));
-  Loc ret = port(2, a_loc);
-  Loc var = port(1, b_loc);
-  Term bod = take(port(2, b_loc));
+static void interact_appref(TM *tm, Term neg, Loc pos_loc) {
+  Term lam = expand_ref(tm, pos_loc);
+  #ifdef DEBUG
+  if (term_tag(lam) != LAM) {
+    // Assumption broken. May not matter, but I want to know.
+    fprintf(stderr, "APPREF root node is not a LAM, %s\n",
+            tag_to_str(term_tag(lam)));
+    exit(1);
+  }
+  #endif
+  // Force push to overflow buffer
+  rbag_push(tm, neg, lam, true);
+}
 
-  // Magic to make race condition appear more frequently
-  //bool buse = tm->buse;
-  //tm->buse = false;
+static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
+  Term arg = take(port(1, a_loc));
+  Loc var = port(1, b_loc);
+  Loc ret = port(2, a_loc);
+  Term bod = take(port(2, b_loc));
 
   move(tm, var, arg);
   move(tm, ret, bod);
-
-  //tm->buse = buse;
-  return true;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1728,7 +1744,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
-  bool processed = true;
+  //bool processed = true;
 
   switch (neg_tag) {
   case APP:
@@ -1743,27 +1759,14 @@ static bool interact(TM *tm, Term neg, Term pos) {
       interact_appu32(tm, neg_loc, pos_loc);
       break;
     case REF:
-#if 1
-      {
-        Term lam = expand_ref(tm, pos_loc);
-        if (term_tag(lam) != LAM) {
-          // Assumption broken. May not matter, but I want to know.
-          fprintf(stderr, "APPREF root node is not a LAM, %s\n",
-                  tag_to_str(term_tag(lam)));
-          exit(1);
-        }
-        // force push to overflow buffer
-        rbag_push(tm, neg, lam, true);
-      }
-#else
-      link_terms(tm, neg, expand_ref(tm, pos_loc);
-#endif
+      interact_appref(tm, neg, pos_loc);
+      //link_terms(tm, neg, expand_ref(tm, pos_loc);
       break;
     case SUP:
       interact_appsup(tm, neg_loc, pos_loc);
       break;
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
@@ -1785,7 +1788,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
@@ -1807,7 +1810,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
@@ -1833,7 +1836,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
       interact_dupsup(tm, neg_loc, pos_loc);
       break;
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
@@ -1855,7 +1858,7 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case LAM:
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
@@ -1871,24 +1874,27 @@ static bool interact(TM *tm, Term neg, Term pos) {
     case U32:
     case REF:
     default:
-      processed = false;
+      //processed = false;
       break;
     }
     break;
   default:
-    processed = false;
+    //processed = false;
     break;
   }
   tm->itrs += 1;
 
+  #if defined(DEBUG)
   if (!processed) {
     unprocessed_itrs[neg_tag * 16 + pos_tag] = 1;
     return false;
   }
+  #endif
 
   return true;
 }
 
+#ifdef DEBUG
 static void show_unprocessed_itrs() {
   for (u32 i = 17; i <= 255; i++) {
     u32 pos_tag = i % 16;
@@ -1904,6 +1910,7 @@ static void show_unprocessed_itrs() {
     }
   }
 }
+#endif
 
 static bool sequential_step(TM* tm) {
   Loc loc = redex_pop_loc(tm);
@@ -1951,7 +1958,7 @@ static bool try_steal(TM *tm) {
       tm->spop = tm->bput;
       tm->sid = tm->tid;
 
-      #if 1 || defined(DEBUG)
+      #if 0 || defined(DEBUG)
       if (bty_debug) {
         fprintf(stderr, "%u stealing from own held bbag!\n", tm->tid);
       }
@@ -1992,7 +1999,7 @@ static bool lala_and_interact(TM *tm, Pair pair) {
       // It was another threads bag - toss it
       bbag_toss(tm);
     } else {
-      #if 1 || defined(DEBUG)
+      #if 0 || defined(DEBUG)
       if (bty_debug) {
         fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
       }
@@ -2012,7 +2019,7 @@ static void* thread_func(void* arg) {
   // Wait until after injection to turn these on
   tm->buse = true;
   tm->ouse = true;
-  u64 do_nothing = 0;
+  //u64 do_nothing = 0;
 
   u64  tick = 0;
   bool busy = tm->tid == 0;
@@ -2035,22 +2042,16 @@ static void* thread_func(void* arg) {
       Pair pair = take_pair(loc);
       lala_and_interact(tm, pair);
 
+      #if 1
       if (tm->bhld && (tm->sid == TPC) && bbag_full(tm)) {
         // We're holding a full, non-stolen booty bag. Consider dropping it.
         if (!rbag_empty(tm) || !oflw_empty(tm)) {
           bbag_drop(tm);
         }
       }
+      #endif
     } else {
-      do_nothing += 1;
-#if 0
-      busy = set_idle(busy);
-      if (!try_steal(tm)) {
-        sched_yield();
-        if (timeout(tick))
-          break;
-      }
-#else
+      //do_nothing += 1;
       if (busy && can_idle(tm)) {
         busy = set_idle(busy);
       }
@@ -2059,17 +2060,16 @@ static void* thread_func(void* arg) {
         if (timeout(tick))
           break;
       }
-#endif
     }
   }
 
-  atomic_fetch_add(&net.nods, tm->nput);
-  atomic_fetch_add(&net.itrs, tm->itrs);
+  //atomic_fetch_add(&net.nods, tm->nput);
+  //atomic_fetch_add(&net.itrs, tm->itrs);
 
-  if (1) {
-    fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u oflw %" PRIu64 " do_nothing %" PRIu64 "\n",
-            tm->tid, tm->itrs, tm->sgud, tm->sbad, noflw, do_nothing);
-  }
+  #ifdef SUMMARY
+  fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u oflw %" PRIu64 "\n"); // do_nothing %" PRIu64 "\n",
+          tm->tid, tm->itrs, tm->sgud, tm->sbad, noflw);//, do_nothing);
+  #endif
   return NULL;
 }
 
@@ -2083,7 +2083,9 @@ static void parallel_normalize() {
     pthread_join(threads[i], NULL);
   }
 
+  #ifdef DEBUG
   show_unprocessed_itrs();
+  #endif
 }
 
 Term normalize(Term term) {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -174,16 +174,17 @@ static Book BOOK = {
 
 // Local Thread Memory
 typedef struct TM {
-  u32 tid;  // thread id
-  Loc nput; // next node allocation attempt index
-  Loc rput; // next rbag push index
-  Loc bput; // next (owned) bbag push index
-  Loc bpop; // next (stolen) bbag pop index
-  u32 btid; // tid from which bbag was stolen
-  u32 sgud; // successful steals
-  u32 sbad; // failed steals
-  u64 itrs; // interaction count
+  u32 tid;   // thread id
+  Loc nput;  // next node allocation attempt index
+  Loc rput;  // next rbag push index
+  Loc bput;  // next (owned) bbag push index
+  Loc bpop;  // next (stolen) bbag pop index + 2
+  u32 btid;  // tid from which bbag was stolen
+  u32 sgud;  // successful steal count
+  u32 sbad;  // failed steal count
+  u64 itrs;  // interaction count
   bool buse; // use booty bag
+  bool bfld; // booty bag was filled during current interaction
 } TM;
 
 static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
@@ -239,6 +240,7 @@ TM *tm_new(u64 tid) {
   tm->sgud = 0;
   tm->sbad = 0;
   tm->buse = false;
+  tm->bfld = false;
   return tm;
 }
 
@@ -456,9 +458,8 @@ static bool bty_time(TM* tm) {
 static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
                               memory_order success_order) {
   u32 orig = expect;
-  bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
-                 desire, success_order, memory_order_relaxed);
-  return res;
+  return atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
+      desire, success_order, memory_order_relaxed);
 }
 
 static void bbag_set(u32 tid, u32 val, memory_order order) {
@@ -466,21 +467,28 @@ static void bbag_set(u32 tid, u32 val, memory_order order) {
 }
 
 static u32 bbag_get(u32 tid) {
-  u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
-  return got;
+  return atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
 }
 
 static Loc get_push_offset(TM *tm) {
+  // TODO: this is a little weird, but made sense yesterday. we only consider
+  // pushing to our booty bag if we aren't popping from a stolen booty bag.
+  // probably the assumption was that if we stole a bag, our bag must be empty
+  // (or stolen). in the empty case, it might be better perf to just push to it.
+  // in the stolen case, what if the bag we stole is our own? also might be 
+  // better perf in this case if we just put ot it.
   if (bty_time(tm)) {
-    // Consider pushing to booty bag
-    if (tm->bput >= BBAG_LEN) {
-      // BBAG is full, last we checked. But maybe it's empty now
-      if (bbag_get(tm->tid) == EMPTY) {
-        tm->bput = 0;
-        return tm->bput;
-      }        
+    if (tm->bput == BBAG_LEN) {
+      // Booty bag is full
+      if (0 && !tm->bfld) {
+        // It wasn't filled during this interaction
+        if (bbag_get(tm->tid) == EMPTY) {
+          tm->bput = 0;
+          return tm->bput;
+        }
+      }
     } else {
-      // BBAG isn't full, use it
+      // Booty bag isn't full
       return tm->bput;
     }
   }
@@ -506,7 +514,8 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   if (bty) {
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
-      bbag_set(tm->tid, FULL, memory_order_release);
+      tm->bfld = true;
+      //bbag_set(tm->tid, FULL, memory_order_release);
     }
   } else {
     //#ifdef DEBUG
@@ -529,10 +538,10 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
 static Pair rbag_pop(TM* tm) {
   if (tm->bpop > 0) {
-    // We stole a booty bag, use it
+    // We have a stolen, non-empty booty bag, use it
     tm->bpop -= 2;
 
-    // If stealing from own booty bag, adjust push index as well
+    // If it's our own booty bag, adjust push index as well
     if (tm->btid == tm->tid) {
       tm->bput -= 2;
     }
@@ -725,8 +734,8 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   }
   #endif
 
-  bool buse = tm->buse;
-  tm->buse = false;
+  //bool buse = tm->buse;
+  //tm->buse = false;
 
   for (u32 i = 0; i < rbag_len; i += 2) {
 #if 1 // old
@@ -741,7 +750,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 #endif
   }
 
-  tm->buse = buse;
+  //tm->buse = buse;
 
   return root;
 }
@@ -786,13 +795,13 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
 
-  bool buse = tm->buse;
+  //bool buse = tm->buse;
   //tm->buse = false;
 
   move(tm, var, arg);
   move(tm, ret, bod);
 
-  tm->buse = buse;
+  //tm->buse = buse;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1172,8 +1181,8 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
     exit(1);
   }
 
-  bool buse = tm->buse;
-  tm->buse = false;
+  //bool buse = tm->buse;
+  //tm->buse = false;
 
   u32 i_arm = (n < mat_len - 1) ? n : (mat_len - 1);
   for (u32 i = 0; i < mat_len; i++) {
@@ -1196,7 +1205,7 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
     link_terms(tm, term_new(APP, 0, app), arm);
   }
 
-  tm->buse = buse;
+  //tm->buse = buse;
 }
 
 static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {
@@ -1466,7 +1475,7 @@ static bool try_steal(TM *tm) {
   return false;
 }
 
-static bool check_timeout(u32 tick) {
+static bool timeout(u32 tick) {
   if (tick % 256 == 0) {
     u32 idle = atomic_load_explicit(&net.idle, memory_order_relaxed);
     if (idle == TPC) {
@@ -1481,6 +1490,18 @@ static bool check_timeout(u32 tick) {
   return false;
 }
 
+static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
+  Pair pair = take_pair(loc);
+
+  //bbag_maybe_empty(tm, prev_bpop);
+  if (from_bty && (tm->bpop == 0) && (tm->btid != tm->tid)) {
+    // The last pair was just popped from a stolen booty bag
+    bbag_set(tm->btid, EMPTY, memory_order_relaxed);
+  }
+  
+  interact(tm, pair_neg(pair), pair_pos(pair));
+}
+
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
   TM *tm = tms[thread_id];
@@ -1489,38 +1510,51 @@ static void* thread_func(void* arg) {
   // TODO: this could be a global net flag i think.
   tm->buse = true;
 
-  //sync_threads();
-
   u32  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
     tick += 1;
     bool bty = tm->bpop > 0; // haxor
+    // TODO: I think i can adjust this to not include RBAG, and thus pass
+    // down the "loc < BBAG_LEN" logic to determine if this was a boot-bag
+    // pop. that might transfer some tid vs. btid computation here though.
     Loc loc = rbag_pop(tm);
     if (loc) {
       busy = set_busy(busy);
 
-      Pair pair = take_pair(loc);
-
-      //bbag_maybe_empty(tm, prev_bpop);
-
-      if (bty) {
-        if (tm->bpop == 0) {
-          if (tm->btid != tm->tid) {
-            // Mark stolen booty bag empty
-            bbag_set(tm->btid, EMPTY, memory_order_relaxed);
-          }
+      // Check if our booty bag has been emptied by whoever stole it
+      if (tm->bput == BBAG_LEN) {
+        // Booty bag was full last we checked, but maybe it's empty now
+        if (bbag_get(tm->tid) == EMPTY) {
+          tm->bput = 0;
         }
       }
-      interact(tm, pair_neg(pair), pair_pos(pair));
+
+      take_and_interact(tm, loc, bty);
+
+      // Possible conditions:
+      // 1. booty bag wasn't full before, but was filled during interaction.
+      // 2. booty bag was full before, we stole our own bag, and re-filled it.
+      // 3. booty bag was full before, was stolen, emptied and released, and
+      //    we re-gained owernship and refilled, all during interaction.
+      //    (seems unlikely, but theoretically possible).
+      if (tm->bfld) {
+        if (tm->bput == BBAG_LEN) {
+          // Booty bag is full, and was filled by the preceding interaction
+          bbag_set(tm->tid, FULL, memory_order_release);
+          //if (!bbag_compare_swap(tm->tid, EMPTY, FULL, memory_order_release)) {
+          //  fprintf(stderr, "OOPS\n");
+          //}
+        }
+        tm->bfld = false;
+      }
     } else {
       busy = set_idle(busy);
-
-      if (try_steal(tm)) continue;
-
-      sched_yield();
-
-      if (check_timeout(tick)) break;
+      if (!try_steal(tm)) {
+        sched_yield();
+        if (timeout(tick))
+          break;
+      }
     }
   }
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -135,7 +135,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 98
+  BBAG_LEN = 8
 };
 
 typedef struct Net {
@@ -216,7 +216,7 @@ void dump_buff(TM *tm);
 
 static const char* term_str(char* buf, Term term);
 
-#define MEMLOG // comment out to disable
+//#define MEMLOG // comment out to disable
 
 #ifdef MEMLOG
 
@@ -228,7 +228,7 @@ static const char* term_str(char* buf, Term term);
 // Memory operations log
 static u32 *MEMBUFF = NULL;
 static a64 MLOG_END = 0;
-static u32 MLOG_MAX = 1U << 24;
+static u32 MLOG_MAX = (1U << 25) * 2 * 5; // 32Mi * (2 ops) * (1 + 2 + 2 = 5 32-bit words per op)
 
 //static _Thread_local u64 rbag_loc = 0;
 #define MLOG(mop, sid, loc, t1, t2) mlog((u32)thread_id, mop, sid, loc, t1, t2)
@@ -239,9 +239,9 @@ static u32 MLOG_MAX = 1U << 24;
 #ifdef MEMLOG
 static void mlog_init() {
   if (MEMBUFF == NULL) {
-    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_MAX * sizeof(u64));
+    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_MAX * sizeof(u32));
   }
-  //memset(MEMBUFF, 0, MLOG_MAX * sizeof(a64));
+  //memset(MEMBUFF, 0, MLOG_MAX * sizeof(u32));
   MLOG_END = 0;
 }
 
@@ -323,7 +323,9 @@ static void mlog_dump(const char* fn) {
   }
   u32 end = atomic_load(&MLOG_END);
   if (end > MLOG_MAX) end = MLOG_MAX;
-  for (u32 i = 0; i < end;) {
+  u32 ops = 0;
+  u32 i = 0;
+  for (; i + 5 <= end; ops += 2) {
     u32 e = MEMBUFF[i++]; // entry
     Term t1 = *(Term*)&MEMBUFF[i];
     i += 2;
@@ -335,20 +337,28 @@ static void mlog_dump(const char* fn) {
             mlog_sid(e), mlog_loc(e), term_str(buf1, t1), term_str(buf2, t2));
   }
   fclose(fp);
+  fprintf(stderr, "ops: %u, idx: %u, end: %u\n", ops, i, end);
 }
 
 static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2) {
+  static bool at_end = false;
+
   // ugly but acceptable load-test-add pattern for debug logging.
   u32 end = atomic_load(&MLOG_END);
   if (end + 5 < MLOG_MAX) {
     end = atomic_fetch_add(&MLOG_END, 5UL);
-    if (end + 5 < MLOG_MAX) {
+    if (end < MLOG_MAX) {
       MEMBUFF[end] = mlog_entry(tid, mop, sid, loc);
       end += 1;
       *(Term*)&MEMBUFF[end] = t1;
       end += 2;
       *(Term*)&MEMBUFF[end] = t2;
+      return;
     }
+  }
+  if (!at_end) {
+    fprintf(stderr, "end of MLOG reached\n");
+    at_end = true;
   }
 }
 #endif // MEMLOG
@@ -671,15 +681,8 @@ static Loc get_push_offset(TM *tm) {
   return BBAG_LEN + tm->rput;
 }
 
+//static void redex_push(TM *tm, Pair pair) {
 static void rbag_push(TM *tm, Term neg, Term pos) {
-#ifdef DEBUG
-  bool free_global = tm->rput < RBAG_LEN - 1;
-  if (!free_global) {
-    fprintf(stderr, "rbag space exhausted\n");
-    exit(1);
-  }
-#endif
-
   Loc off = get_push_offset(tm);
   bool bty = off < BBAG_LEN;
   Loc loc = RBAG + tm->tid * RBAG_LEN + off;
@@ -694,28 +697,46 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   set_pair(loc, pair_new(neg, pos));
 
   if (bty) {
-    MLOG(MOP_STOR, tm->tid, tm->bput, neg, pos);
+    //MLOG(MOP_STOR, tm->tid, tm->bput, pair_neg(pair), pair_pos(pair));
+    //MLOG(MOP_STOR, tm->tid, tm->bput, neg, pos);
 
     if (1 && bty_debug) {
       fprintf(stderr, "%u pushed to booty bag @ %u\n", tm->tid, tm->bput);
       char buf[TERMSTR_BUFSIZ];
+      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
+      //fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
       fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, neg));
       fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pos));
     }
 
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
-      atomic_thread_fence(memory_order_release);
-      bbag_set(tm->tid, FULL, memory_order_relaxed);
+      bbag_set(tm->tid, FULL, memory_order_release);
 
       if (0 && bty_debug) {
         fprintf(stderr, "%u booty bag full\n", tm->tid);
       }
     }
   } else {
+    //MLOG(MOP_STOR, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
+
+    //#ifdef DEBUG
+    bool free_global = tm->rput < RBAG_LEN - BBAG_LEN - 1;
+    if (!free_global) {
+      fprintf(stderr, "rbag space exhausted\n");
+      exit(1);
+    }
+    //#endif
+
     tm->rput += 2;
   }
 }
+
+/*
+static void rbag_push(TM *tm, Term neg, Term pos) {
+  redex_push(tm, pair_new(neg, pos));
+}
+*/
 
 static Pair rbag_pop(TM* tm) {
   if (tm->bpop > 0) {
@@ -725,6 +746,14 @@ static Pair rbag_pop(TM* tm) {
     // If stealing from own booty bag, adjust push index as well
     if (tm->btid == tm->tid) {
       tm->bput -= 2;
+
+      #if 0
+      // Debugging
+      if (tm->bput != tm->bpop) {
+        fprintf(stderr, "bput: %u, bpop: %u\n", tm->bput, tm->bpop);
+        exit(1);
+      }
+      #endif
     }
 
     if (bty_debug) {
@@ -926,15 +955,21 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   }
   #ifdef STORE_128
   if (n < nodes_len) {
-    Term term = term_offset_loc(nodes[n], offset);
-    BUFF[offset + n] = term;
+    BUFF[offset + n] = term_offset_loc(nodes[n], offset);
   }
   #endif
 
   for (u32 i = 0; i < rbag_len; i += 2) {
+#if 1 // old
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i + 1], offset);
     rbag_push(tm, neg, pos);
+#else
+    // 128-bit load
+    Pair = *(Pair*)&rbag[i];
+    rbag_push(tm, pair_neg(pair), pair_pos(pair));
+    //redex_push(tm, pair); 
+#endif
   }
   return root;
 }
@@ -1026,9 +1061,9 @@ static void interact_opxnul(TM *tm, Loc a_loc) {
   move(tm, ret, term_new(NUL, 0, 0));
 }
 
-static void interact_opxnum(TM *tm, Loc a_loc, Lab op, u32 num, Tag num_type) {
-  Term arg = swap(port(1, a_loc), term_new(num_type, 0, num));
-  link_terms(tm, term_new(OPY, op, a_loc), arg);
+static void interact_opxnum(TM *tm, Loc loc, Lab op, u32 num, Tag num_type) {
+  Term arg = swap(port(1, loc), term_new(num_type, 0, num));
+  link_terms(tm, term_new(OPY, op, loc), arg);
 }
 
 static void interact_opxsup(TM *tm, Loc a_loc, Lab op, Loc b_loc) {
@@ -1444,7 +1479,8 @@ static void interact(TM *tm, Term neg, Term pos) {
   case APP:
     switch (pos_tag) {
     case LAM:
-      interact_applam(tm, neg_loc, pos_loc); break;
+      interact_applam(tm, neg_loc, pos_loc);
+      break;
     case NUL:
       interact_appnul(tm, neg_loc);
       break;
@@ -1707,7 +1743,7 @@ static void* thread_func(void* arg) {
   bool busy = tm->tid == 0;
   while (true) {
     tick += 1;
-    Loc prev_bpop = tm->bpop; // haxor
+    bool bty = tm->bpop > 0; // haxor
     Loc loc = rbag_pop(tm);
     if (loc) {
       busy = set_busy(busy);
@@ -1716,8 +1752,8 @@ static void* thread_func(void* arg) {
 
       //bbag_maybe_empty(tm, prev_bpop);
 
-      if (prev_bpop > 0) {
-        MLOG(MOP_LOAD, tm->btid, tm->bpop, pair_neg(pair), pair_pos(pair));
+      if (bty) {
+        //MLOG(MOP_LOAD, tm->btid, tm->bpop, pair_neg(pair), pair_pos(pair));
 
         if (1 && bty_debug) {
           char buf[TERMSTR_BUFSIZ];
@@ -1741,6 +1777,8 @@ static void* thread_func(void* arg) {
             }
           }
         }
+      } else {
+        //MLOG(MOP_LOAD, tm->tid + 10, tm->rput, pair_neg(pair), pair_pos(pair));
       }
 
       if (pair != 0) {
@@ -1810,11 +1848,13 @@ Term normalize(Term term) {
     parallel_normalize();
   }
 
+  return get(0);
+}
+
+void handle_failure() {
 #ifdef MEMLOG
   mlog_dump("memlog.txt");
 #endif
-
-  return get(0);
 }
 
 // Debugging

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -184,7 +184,7 @@ typedef struct TM {
   u32 sbad;  // failed steal count
   u64 itrs;  // interaction count
   bool buse; // use booty bag
-  bool bfld; // booty bag was filled during current interaction
+  bool bfld; // bbag was filled during current interaction
 } TM;
 
 static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
@@ -196,7 +196,6 @@ enum : u32 {
   STOLEN = 2
 };
 
-// Booty bag state
 typedef struct BB {
   a32 ctrl; // control word
 } BB;
@@ -211,7 +210,7 @@ static _Thread_local int thread_id = 0;
 static char *tag_to_str(Tag tag);
 static char *bty_ctrl_str(u32 ctrl);
 static void dump_term(Loc loc);
-void dump_buff(TM *tm);
+void dump_buff();
 
 #define TERMSTR_BUFSIZ 128
 
@@ -393,7 +392,7 @@ static Pair take_pair(Loc loc) {
 
 #ifdef VOID_TEST
   if (pair == 0) {
-    fprintf(stderr, "%d VOID term taken\n", thread_id);
+    fprintf(stderr, "%d VOID pair taken\n", thread_id);
     exit(1);
   }
 #endif
@@ -430,24 +429,26 @@ static Loc port(u64 n, Loc loc) { return n + loc - 1; }
 // Allocator
 // ---------
 
-static Loc node_alloc(TM *tm, u32 num) {
+static Loc node_alloc(TM *tm, u32 cnt) {
 #ifdef DEBUG
   if (mop_debug) {
-    fprintf(stderr, "%u alloc %u nodes at %u\n", tm->tid, num, tm->nput);
+    fprintf(stderr, "%u node alloc cnt: %u, nput: %u\n", tm->tid, cnt,
+            tm->nput);
   }
 #endif
 
-  if ((num & 1) == 1) {
-    num += 1;
+  if ((cnt & 1) == 1) {
+    cnt += 1;
   }
 
-  if (tm->nput + num >= NODE_LEN) {
-    fprintf(stderr, "node space exhausted\n");
+  if (tm->nput + cnt >= NODE_LEN) {
+    fprintf(stderr, "%u node space exhausted, nput: %u, cnt: %u, LEN: %u\n",
+            tm->tid, tm->nput, cnt, NODE_LEN);
     exit(1);
   }
 
   Loc loc = tm->tid * NODE_LEN + tm->nput;
-  tm->nput += num;
+  tm->nput += cnt;
   return loc;
 }
 
@@ -457,7 +458,6 @@ static bool bty_time(TM* tm) {
  
 static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
                               memory_order success_order) {
-  u32 orig = expect;
   return atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
       desire, success_order, memory_order_relaxed);
 }
@@ -478,7 +478,12 @@ static Loc get_push_offset(TM *tm) {
   // in the stolen case, what if the bag we stole is our own? also might be 
   // better perf in this case if we just put ot it.
   if (bty_time(tm)) {
-    if (tm->bput == BBAG_LEN) {
+    if (tm->bput < BBAG_LEN) {
+      // Booty bag isn't full, push to it
+      return tm->bput;
+    }
+    /*
+    else {
       // Booty bag is full
       if (0 && !tm->bfld) {
         // It wasn't filled during this interaction
@@ -487,16 +492,13 @@ static Loc get_push_offset(TM *tm) {
           return tm->bput;
         }
       }
-    } else {
-      // Booty bag isn't full
-      return tm->bput;
     }
+    */
   }
   // Push to RBAG
   return BBAG_LEN + tm->rput;
 }
 
-//static void redex_push(TM *tm, Pair pair) {
 static void rbag_push(TM *tm, Term neg, Term pos) {
   Loc off = get_push_offset(tm);
   bool bty = off < BBAG_LEN;
@@ -514,6 +516,7 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   if (bty) {
     tm->bput += 2;
     if (tm->bput == BBAG_LEN) {
+      // Booty bag was filled during this interaction
       tm->bfld = true;
       //bbag_set(tm->tid, FULL, memory_order_release);
     }
@@ -530,28 +533,23 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   }
 }
 
-/*
-static void rbag_push(TM *tm, Term neg, Term pos) {
-  redex_push(tm, pair_new(neg, pos));
-}
-*/
-
 static Pair rbag_pop(TM* tm) {
   if (tm->bpop > 0) {
-    // We have a stolen, non-empty booty bag, use it
+    // Pop from stolen, non-empty booty bag
     tm->bpop -= 2;
 
-    // If it's our own booty bag, adjust push index as well
+    // If we stole our own booty bag, adjust push index as well
     if (tm->btid == tm->tid) {
       tm->bput -= 2;
     }
 
     return RBAG + tm->btid * RBAG_LEN + tm->bpop;
   } else if (tm->rput > 0) {
-    // RBAG isn't empty, use it
+    // Pop from non-empty RBAG
     tm->rput -= 2;
     return RBAG + tm->tid * RBAG_LEN + BBAG_LEN + tm->rput;
   } else {
+    // Steal from someone else
     return 0;
   }
 }
@@ -687,6 +685,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   const u32 rbag_len = def->rbag_len;
 
   // offset calculation must occur before node_alloc() call
+  // TODO: i think we can use the return value of node_alloc() here
   Loc offset = (tm->tid * NODE_LEN) + tm->nput - 1;
 
 #ifdef DEBUG
@@ -700,58 +699,46 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   Term root = term_offset_loc(nodes[0], offset);
 
-  // No redexes reference these nodes yet; safe to add without atomics.
-  // TODO: ensure nodes always 16-byte aligned to enable 128-bit stores
-  #define STORE_128
-  #ifndef STORE_128
+  // No redexes reference these nodes yet; safe to add without atomics
+#define NODE_128
+#ifndef NODE_128 // old
   for (u32 n = 1; n < nodes_len; n++) {
-  #else
-  u32 n = 1;
-  for (; n + 1 < nodes_len; n += 2) {
-  #endif
     Loc loc = offset + n;
-
-    #ifndef STORE_128
     Term term = term_offset_loc(nodes[n], offset);
     BUFF[loc] = term;
-    #else
+  }
+#else
+  u32 n = 1;
+  for (; n + 1 < nodes_len; n += 2) {
+    Loc loc = offset + n;
+    // 128-bit load & store
     Pair pair = *(Pair*)&nodes[n];
     *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
                                   term_offset_loc(pair_pos(pair), offset));
-
-    #endif
-
-#ifdef DEBUG
-    if (mop_debug) {
-      char buf[TERMSTR_BUFSIZ];
-      fprintf(stderr, "%u node %u %s\n", tm->tid, loc, term_str(buf, term));
-    }
-#endif
   }
-  #ifdef STORE_128
   if (n < nodes_len) {
     BUFF[offset + n] = term_offset_loc(nodes[n], offset);
   }
-  #endif
+#endif
 
-  //bool buse = tm->buse;
-  //tm->buse = false;
-
+#if 0
   for (u32 i = 0; i < rbag_len; i += 2) {
-#if 1 // old
+#else
+  // reverse order
+  for (int i = rbag_len - 2; i >= 0; i -= 2) {
+#endif
+
+#ifndef NODE_128 // old
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i + 1], offset);
     rbag_push(tm, neg, pos);
 #else
     // 128-bit load
-    Pair = *(Pair*)&rbag[i];
-    rbag_push(tm, pair_neg(pair), pair_pos(pair));
-    //redex_push(tm, pair); 
+    Pair pair = *(Pair*)&rbag[i];
+    rbag_push(tm, term_offset_loc(pair_neg(pair), offset),
+              term_offset_loc(pair_pos(pair), offset));
 #endif
   }
-
-  //tm->buse = buse;
-
   return root;
 }
 
@@ -794,14 +781,8 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
-
-  //bool buse = tm->buse;
-  //tm->buse = false;
-
   move(tm, var, arg);
   move(tm, ret, bod);
-
-  //tm->buse = buse;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1181,9 +1162,6 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
     exit(1);
   }
 
-  //bool buse = tm->buse;
-  //tm->buse = false;
-
   u32 i_arm = (n < mat_len - 1) ? n : (mat_len - 1);
   for (u32 i = 0; i < mat_len; i++) {
     if (i != i_arm) {
@@ -1193,7 +1171,6 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
 
   Loc ret = port(1, mat_loc);
   Term arm = take(port(2 + i_arm, mat_loc));
-
   if (i_arm < mat_len - 1) {
     move(tm, ret, arm);
   } else {
@@ -1204,24 +1181,16 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
 
     link_terms(tm, term_new(APP, 0, app), arm);
   }
-
-  //tm->buse = buse;
 }
 
 static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {
   fprintf(stderr, "interact_matsup not supported (yet)\n");
   exit(1);
-  // TODO: convert to get_resources()
+  // TODO: convert to node_alloc( 2 + mat_len * 3)
 
   /*
-  // TODO: recoverable
-  if (!get_resources(tm, 0, 2 + mat_len * 3)) {
-    fprintf(stderr, "i_appsup: Thread %u node space exhausted\n", tm->tid);
-    exit(1);
-  }
   Loc ma0 = alloc_node(1 + mat_len);
   Loc ma1 = alloc_node(1 + mat_len);
-
   Loc sup = alloc_node(2);
 
   set(port(1, sup), term_new(VAR, 0, port(1, ma1)));
@@ -1233,7 +1202,6 @@ static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {
     Loc dui = alloc_node(2);
     set(port(1, dui), term_new(SUB, 0, 0));
     set(port(2, dui), term_new(SUB, 0, 0));
-    // TODO: problematic port() usage with recycled nodes
     set(port(2 + i, ma0), term_new(VAR, 0, port(2, dui)));
     set(port(2 + i, ma1), term_new(VAR, 0, port(1, dui)));
 
@@ -1404,33 +1372,16 @@ static inline bool sequential_step(TM* tm) {
   return true;
 }
 
-// A simple spin-wait barrier using atomic operations
-a64 a_reached = 0; // number of threads that reached the current barrier
-a64 a_barrier = 0; // number of barriers passed during this program
-static void sync_threads() {
-  u64 barrier_old = atomic_load_explicit(&a_barrier, memory_order_relaxed);
-  if (atomic_fetch_add_explicit(&a_reached, 1, memory_order_relaxed) == (TPC - 1)) {
-    // Last thread to reach the barrier resets the counter and advances the barrier
-    atomic_store_explicit(&a_reached, 0, memory_order_relaxed);
-    atomic_store_explicit(&a_barrier, barrier_old + 1, memory_order_release);
-  } else {
-    u32 tries = 0;
-    while (atomic_load_explicit(&a_barrier, memory_order_acquire) == barrier_old) {
-      sched_yield();
-    }
-  }
-}
-
 static bool set_idle(bool was_busy) {
   if (was_busy) {
-    u32 idle = atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
   }
   return false;
 }
 
 static bool set_busy(bool was_busy) {
   if (!was_busy) {
-    u32 idle = atomic_fetch_sub_explicit(&net.idle, 1, memory_order_relaxed);
+    atomic_fetch_sub_explicit(&net.idle, 1, memory_order_relaxed);
   }
   return true;
 }
@@ -1443,7 +1394,8 @@ static bool try_steal(TM *tm) {
   if (!tm->buse) return false;
 
   if (tm->bput > 0) {
-    // Our own booty bag has something in it
+    // Our booty bag has something in it
+    // TODO: combine these two conditions into one compound condition
     if (tm->bput < BBAG_LEN) {
       // Booty bag isn't full, so we can steal without atomics
       tm->bpop = tm->bput;
@@ -1453,7 +1405,7 @@ static bool try_steal(TM *tm) {
     } else {
       // To steal from our own full bag, we need to take back ownership
       if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
-        tm->bpop = tm->bput; // BBAG_LEN, always
+        tm->bpop = tm->bput; // will always be BBAG_LEN
         tm->btid = tm->tid;
 
         return true;
@@ -1479,13 +1431,8 @@ static bool timeout(u32 tick) {
   if (tick % 256 == 0) {
     u32 idle = atomic_load_explicit(&net.idle, memory_order_relaxed);
     if (idle == TPC) {
-     return true;
+      return true;
     }
-#ifdef DEBUG
-    if (thd_debug) {
-      fprintf(stderr, "%u idle, total: %u\n", thread_id, idle);
-    }
-#endif
   }
   return false;
 }
@@ -1493,7 +1440,6 @@ static bool timeout(u32 tick) {
 static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
   Pair pair = take_pair(loc);
 
-  //bbag_maybe_empty(tm, prev_bpop);
   if (from_bty && (tm->bpop == 0) && (tm->btid != tm->tid)) {
     // The last pair was just popped from a stolen booty bag
     bbag_set(tm->btid, EMPTY, memory_order_relaxed);
@@ -1514,17 +1460,17 @@ static void* thread_func(void* arg) {
   bool busy = tm->tid == 0;
   while (true) {
     tick += 1;
+
     bool bty = tm->bpop > 0; // haxor
-    // TODO: I think i can adjust this to not include RBAG, and thus pass
-    // down the "loc < BBAG_LEN" logic to determine if this was a boot-bag
-    // pop. that might transfer some tid vs. btid computation here though.
+    // TODO: I think i can adjust rbag_pop() to not include RBAG, and thus pass
+    // down the "loc < BBAG_LEN" logic to here in order to determine if this
+    // was a booty-bag pop. That'll move some tid vs. btid logic here though.
     Loc loc = rbag_pop(tm);
     if (loc) {
       busy = set_busy(busy);
 
-      // Check if our booty bag has been emptied by whoever stole it
       if (tm->bput == BBAG_LEN) {
-        // Booty bag was full last we checked, but maybe it's empty now
+        // We *think* booty bag is full, but it may have been stolen and emptied
         if (bbag_get(tm->tid) == EMPTY) {
           tm->bput = 0;
         }
@@ -1532,20 +1478,9 @@ static void* thread_func(void* arg) {
 
       take_and_interact(tm, loc, bty);
 
-      // Possible conditions:
-      // 1. booty bag wasn't full before, but was filled during interaction.
-      // 2. booty bag was full before, we stole our own bag, and re-filled it.
-      // 3. booty bag was full before, was stolen, emptied and released, and
-      //    we re-gained owernship and refilled, all during interaction.
-      //    (seems unlikely, but theoretically possible).
       if (tm->bfld) {
-        if (tm->bput == BBAG_LEN) {
-          // Booty bag is full, and was filled by the preceding interaction
-          bbag_set(tm->tid, FULL, memory_order_release);
-          //if (!bbag_compare_swap(tm->tid, EMPTY, FULL, memory_order_release)) {
-          //  fprintf(stderr, "OOPS\n");
-          //}
-        }
+        // Booty bag was filled by the preceding interaction
+        bbag_set(tm->tid, FULL, memory_order_release);
         tm->bfld = false;
       }
     } else {
@@ -1662,6 +1597,7 @@ static void dump_term(Loc loc) {
 }
 
 // FILE VERSION: (or you can >> the stdio into a file)
+// NOTE: broken don't use without fixing.
 /*void dump_buff() {*/
 /*  FILE *file = fopen("multi.txt", "w");*/
 /*  if (file == NULL) {*/
@@ -1702,7 +1638,7 @@ static void dump_term(Loc loc) {
 /*  fclose(file);*/
 /*}*/
 // STD VERSION
-void dump_buff(TM *tm) {
+void tm_dump_buff(TM *tm) {
   printf("------------------\n");
   printf("      NODES\n");
   printf("ADDR   LOC LAB TAG\n");
@@ -1710,11 +1646,6 @@ void dump_buff(TM *tm) {
   for (Loc idx = 0; idx < tm->nput; idx++) {
     Loc loc = tm->tid * NODE_LEN + idx;
     dump_term(loc);
-/*
-    Term term = get(loc);
-    printf("%06X %03X %03X %s\n", loc, term_loc(term), term_lab(term),
-        tag_to_str(term_tag(term)));
-*/
   }
   printf("------------------\n");
   printf("    REDEX BAG\n");
@@ -1725,4 +1656,8 @@ void dump_buff(TM *tm) {
     dump_term(loc);
   }
   printf("------------------\n");
+}
+ 
+void dump_buff() {
+  tm_dump_buff(tms[0]);
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -130,7 +130,7 @@ enum : u32 {
   RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(u64)) & ~7U, // CACH_U64 - 1
 
   // Calculate RBAG_LEN and NODE_LEN: number of u64 elements *per thread*
-  // MUST be 16-byte aligned. 64-byte alignment might be preferable
+  // RBAG_LEN MUST be 16-byte aligned. 64-byte alignment might be preferable
   RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~7U, // CACH_U64 - 1
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
@@ -172,6 +172,8 @@ static Book BOOK = {
   .cap = 0,
 };
 
+#define MBUF_SIZ 10
+
 // Local Thread Memory
 typedef struct TM {
   u32 tid;  // thread id
@@ -184,9 +186,14 @@ typedef struct TM {
   u32 sbad; // failed steals
   u64 itrs; // interaction count
   bool buse; // use booty bag
+  bool muse; // use mlog
+  u32 mput;
+  #if 0
+  u32 mbuf[MBUF_SIZ];
+  #endif
 } TM;
 
-static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
+//static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
 
 // Booty bag control word values
 enum : u32 {
@@ -226,23 +233,28 @@ static const char* term_str(char* buf, Term term);
 #define MOP_STOR 0x03
 
 // Memory operations log
-static u32 *MEMBUFF = NULL;
-static a64 MLOG_END = 0;
-static u32 MLOG_MAX = (1U << 25) * 2 * 5; // 32Mi * (2 ops) * (1 + 2 + 2 = 5 32-bit words per op)
+static u64 *MEMBUFF = NULL;
+//static a64 MLOG_END = 0;
+enum : u32 {
+  MLOG_SIZ = (1U << 28) * sizeof(u64),
+  MLOG_LEN = MLOG_SIZ / (TPC * sizeof(u64))
+};
 
 //static _Thread_local u64 rbag_loc = 0;
-#define MLOG(mop, sid, loc, t1, t2) mlog((u32)thread_id, mop, sid, loc, t1, t2)
+#define MLOG(mop, loc, t1, t2)          mlog((u32)thread_id, mop, 0, loc, t1, t2, 0)
+#define MLOG_LVL(mop, loc, lvl, t1, t2) mlog((u32)thread_id, mop, 0, loc, t1, t2, lvl)
 #else
-#define MLOG(mop, sid, loc, t1, t2)
+#define MLOG(mop, loc, t1, t2)
+#define MLOG_LVL(mop, loc, lvl, t1, t2)
 #endif
 
 #ifdef MEMLOG
 static void mlog_init() {
   if (MEMBUFF == NULL) {
-    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_MAX * sizeof(u32));
+    MEMBUFF = aligned_alloc(CACH_SIZ, MLOG_SIZ);
   }
   //memset(MEMBUFF, 0, MLOG_MAX * sizeof(u32));
-  MLOG_END = 0;
+  //MLOG_END = 0;
 }
 
 static void mlog_free() {
@@ -252,59 +264,41 @@ static void mlog_free() {
   }
 }
 
-// op:3, loc: 7, tid: 4, sid: 4
-static u32 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc) {
-  return (mop << 15) | ((loc & 0x7F) << 8) | ((tid & 0xF) << 4) | (sid & 0xF);
+// lvl: 5, op:3, loc: 7, tid: 4, sid: 4
+static u64 mlog_entry(u32 tid, u32 mop, u32 sid, u32 loc, u32 lvl) {
+  u64 hi = (lvl << 18) | ((mop & 0x7) << 15) | ((loc & 0x7F) << 8) | ((tid & 0xF) << 4) | (sid & 0xF);
+  return hi << 32 | loc;
 }
 
-static u32 mlog_mop(u32 e) {
-  return e >> 15;
+static u32 mlog_hi(u64 e) {
+  return e >> 32;
 }
 
-static u32 mlog_loc(u32 e) {
-  return (e >> 8) & 0x7F;
+static u32 mlog_lvl(u64 e) {
+  return mlog_hi(e) >> 18;
 }
 
-static u32 mlog_tid(u32 e) {
-  return (e >> 4) & 0xF;
+static u32 mlog_mop(u64 e) {
+  return (mlog_hi(e) >> 15) & 0x7;
+}
+
+/*
+static u32 mlog_loc(u64 e) {
+  return (mlog_hi(e) >> 8) & 0x7F;
+}
+*/
+
+static u32 mlog_tid(u64 e) {
+  return (mlog_hi(e) >> 4) & 0xF;
 }
 
 static u32 mlog_sid(u64 e) {
-  return e & 0xF;
+  return mlog_hi(e) & 0xF;
 }
 
-#if 0
-// hi 32 bits: tid: 5, mop: 2, itr: 5, term_tag: 8
-// lo 32 bits: rbag_loc
-static u64 mlog_entry(u32 tid, u32 mop, u32 itr, Term term, u64 rbag_loc) {
-  u64 hi = (tid << 15) | ((mop & 0x3) << 13) | ((itr & 0x1F) << 8) | term_tag(term);
-  return (hi << 32) | (rbag_loc & 0xFFFFFFFF);
+static u32 mlog_loc(u64 e) {
+  return e & 0xFFFFFFFF;
 }
-
-static u32 mlog_entry_hi(u64 entry) {
-  return (entry >> 32) & 0xFFFFFFFF;
-}
-
-static u32 mlog_itr(u64 entry) {
-  return (mlog_entry_hi(entry) >> 8) & 0x1F;
-}
-
-static u32 mlog_term_tag(u64 entry) {
-  return mlog_entry_hi(entry) & 0xFF;
-}
-
-static u32 mlog_rbag_loc(u64 entry) {
-  return entry & 0xFFFFFFFF;
-}
-
-static u32 mlog_loc(u64 locs) {
-  return (locs >> 32) & 0xFFFFFFFF;
-}
-
-static u32 mlog_term_loc(u64 locs) {
-  return locs & 0xFFFFFFFF;
-}
-#endif
 
 static const char* mop_str(u32 mop) {
   switch (mop) {
@@ -321,26 +315,69 @@ static void mlog_dump(const char* fn) {
     perror("mlog_dump: Error opening file");
     return;
   }
-  u32 end = atomic_load(&MLOG_END);
-  if (end > MLOG_MAX) end = MLOG_MAX;
+
   u32 ops = 0;
-  u32 i = 0;
-  for (; i + 5 <= end; ops += 2) {
-    u32 e = MEMBUFF[i++]; // entry
-    Term t1 = *(Term*)&MEMBUFF[i];
-    i += 2;
-    Term t2 = *(Term*)&MEMBUFF[i];
-    i += 2;
-    char buf1[TERMSTR_BUFSIZ];
-    char buf2[TERMSTR_BUFSIZ];
-    fprintf(fp, "%u,%s,%u,%u,%s,%s\n", mlog_tid(e), mop_str(mlog_mop(e)),
-            mlog_sid(e), mlog_loc(e), term_str(buf1, t1), term_str(buf2, t2));
+  for (u64 t = 0; t < TPC; t++) {
+    TM *tm = tms[t];
+    for (u32 i = 0; i < tm->mput; i += 2) {
+      u32 pos = t * MLOG_LEN + i;
+      u64 cnt = MEMBUFF[pos]; 
+      u64 e = MEMBUFF[pos+1]; // entry
+
+      /*
+      Term t1 = *(Term*)&MEMBUFF[i+1];
+      Term t2 = *(Term*)&MEMBUFF[i];
+      char buf1[TERMSTR_BUFSIZ];
+      char buf2[TERMSTR_BUFSIZ];
+      */
+      fprintf(fp, "%" PRIu64 ",%u,%s,%u,%u\n", cnt, mlog_tid(e), mop_str(mlog_mop(e)),
+              /*mlog_sid(e),*/ mlog_lvl(e), mlog_loc(e));
+      //, term_str(buf1, t1), term_str(buf2, t2));
+    }
   }
   fclose(fp);
-  fprintf(stderr, "ops: %u, idx: %u, end: %u\n", ops, i, end);
+  //  fprintf(stderr, "ops: %u\n", ops);
 }
 
-static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2) {
+#ifdef __APPLE__
+// Use explicit file-scope assembly to define the function
+extern uint64_t read_cntvct(void);
+__asm__(
+    ".global _read_cntvct\n"
+    ".global read_cntvct\n"
+    "_read_cntvct:\n"
+    "read_cntvct:\n"
+    //"   isb\n"
+    "   mrs x0, cntvct_el0\n"
+    "   ret\n"
+);
+#endif
+
+static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2, u32 lvl) {
+  static bool at_end = false;
+
+  TM *tm = tms[tid];
+  if (tm->mput + 2 < MLOG_LEN) {
+    u32 pos = tid * MLOG_LEN + tm->mput;
+
+    MEMBUFF[pos] = read_cntvct();
+    MEMBUFF[pos+1] = mlog_entry(tid, mop, sid, loc, lvl);
+
+    /*
+    *(Term*)&MEMBUFF[end] = t1;
+    end += 2;
+    *(Term*)&MEMBUFF[end] = t2;
+    */
+
+    tm->mput += 2;
+  } else if (!at_end) {
+    fprintf(stderr, "%u end of MLOG reached\n", tid);
+    at_end = true;
+  }
+}
+
+/*
+static void mlog_lvl(u32 tid, u32 mop, u32 sid, u32 lvl, Loc loc, Term t1, Term t2) {
   static bool at_end = false;
 
   // ugly but acceptable load-test-add pattern for debug logging.
@@ -361,6 +398,7 @@ static void mlog(u32 tid, u32 mop, u32 sid, Loc loc, Term t1, Term t2) {
     at_end = true;
   }
 }
+*/
 #endif // MEMLOG
 
 void mlog_exit() {
@@ -376,6 +414,8 @@ void tm_reset(TM *tm) {
   tm->rput = 0;
   tm->nput = 0;
   tm->itrs = 0;
+
+  tm->mput = 0;
 }
 
 TM *tm_new(u64 tid) {
@@ -394,6 +434,8 @@ TM *tm_new(u64 tid) {
   tm->sgud = 0;
   tm->sbad = 0;
   tm->buse = false;
+
+  tm->muse = false;
   return tm;
 }
 
@@ -489,56 +531,31 @@ static const char* term_str(char* buf, Term term) {
 }
 
 // Memory operations
-Term swap(Loc loc, Term term) {
+Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term res = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-
-#ifdef DEBUG
-  if (mop_debug)) {
-    char buf1[TERMSTR_BUFSIZ];
-    char buf2[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d swap %u %s with %s\n", thread_id, loc,
-        term_str(buf1, res), term_str(buf2, term));
-  }
-#endif
-
+  MLOG_LVL(MOP_EXCH, loc, lvl, res, term);
   return res;
+}
+
+Term swap(Loc loc, Term term) {
+  return swap_lvl(loc, term, 0);
 }
 
 Term get(Loc loc) {
   Term term = atomic_load_explicit((a64*)&BUFF[loc], memory_order_relaxed);
-
-#ifdef DEBUG
-  if (mop_debug) {
-    char buf[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d get %u %s\n", thread_id, loc, term_str(buf, term));
-  }
-#endif
-
+  MLOG(MOP_LOAD, loc, term, 0);
   return term;
 }
 
 Term take(Loc loc) {
   Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
-
-#ifdef DEBUG
-  if (mop_debug) {
-    char buf[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d take %u %s\n", thread_id, loc, term_str(buf, term));
-  }
-#endif
-
+  MLOG(MOP_EXCH, loc, term, 0);
   return term;
 }
 
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-
-#ifdef DEBUG
-  if (mop_debug) {
-    char buf[TERMSTR_BUFSIZ];
-    fprintf(stderr, "%d set %u %s\n", thread_id, loc, term_str(buf, term));
-  }
-#endif
+  MLOG(MOP_STOR, loc, term, 0);
 }
 
 static Pair take_pair(Loc loc) {
@@ -548,7 +565,7 @@ static Pair take_pair(Loc loc) {
 #else
   Pair pair = *(Pair*)&BUFF[loc];
   //#define VOID_TEST
-  #ifdef VOID_TEST
+#ifdef VOID_TEST
   *(Pair*)&BUFF[loc] = (Pair)VOID;
   #endif
 #endif
@@ -682,7 +699,7 @@ static Loc get_push_offset(TM *tm) {
 }
 
 //static void redex_push(TM *tm, Pair pair) {
-static void rbag_push(TM *tm, Term neg, Term pos) {
+static Loc rbag_push(TM *tm, Term neg, Term pos) {
   Loc off = get_push_offset(tm);
   bool bty = off < BBAG_LEN;
   Loc loc = RBAG + tm->tid * RBAG_LEN + off;
@@ -730,6 +747,7 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
 
     tm->rput += 2;
   }
+  return loc;
 }
 
 /*
@@ -912,65 +930,37 @@ static Term expand_ref(TM *tm, Loc def_idx) {
 
   // offset calculation must occur before node_alloc() call
   Loc offset = (tm->tid * NODE_LEN) + tm->nput - 1;
-
-#ifdef DEBUG
-  if (mop_debug) {
-    fprintf(stderr, "%u expand_ref %u nodes %u rbag %u offset %u\n", tm->tid,
-        def_idx, nodes_len, rbag_len, offset);
-  }
-#endif
-
   node_alloc(tm, nodes_len - 1);
 
   Term root = term_offset_loc(nodes[0], offset);
 
   // No redexes reference these nodes yet; safe to add without atomics.
   // TODO: ensure nodes always 16-byte aligned to enable 128-bit stores
-  #define STORE_128
-  #ifndef STORE_128
-  for (u32 n = 1; n < nodes_len; n++) {
-  #else
   u32 n = 1;
   for (; n + 1 < nodes_len; n += 2) {
-  #endif
-    
     Loc loc = offset + n;
-
-    #ifndef STORE_128
-    Term term = term_offset_loc(nodes[n], offset);
-    BUFF[loc] = term;
-    #else
     Pair pair = *(Pair*)&nodes[n];
     *(Pair*)&BUFF[loc] = pair_new(term_offset_loc(pair_neg(pair), offset),
                                   term_offset_loc(pair_pos(pair), offset));
-
-    #endif
-
-#ifdef DEBUG
-    if (mop_debug) {
-      char buf[TERMSTR_BUFSIZ];
-      fprintf(stderr, "%u node %u %s\n", tm->tid, loc, term_str(buf, term));
-    }
-#endif
   }
-  #ifdef STORE_128
   if (n < nodes_len) {
     BUFF[offset + n] = term_offset_loc(nodes[n], offset);
   }
-  #endif
 
   for (u32 i = 0; i < rbag_len; i += 2) {
-#if 1 // old
-    Term neg = term_offset_loc(rbag[i], offset);
-    Term pos = term_offset_loc(rbag[i + 1], offset);
-    rbag_push(tm, neg, pos);
-#else
     // 128-bit load
-    Pair = *(Pair*)&rbag[i];
-    rbag_push(tm, pair_neg(pair), pair_pos(pair));
-    //redex_push(tm, pair); 
-#endif
+    Pair pair = *(Pair*)&rbag[i];
+    Loc loc = rbag_push(tm, term_offset_loc(pair_neg(pair), offset),
+                        term_offset_loc(pair_pos(pair), offset));
+    #if 0
+    if (def_idx == 5) {
+      if (tm->mput < MBUF_SIZ) {
+        tm->mbuf[tm->mput++] = loc;
+      }
+    }
+    #endif
   }
+
   return root;
 }
 
@@ -985,25 +975,42 @@ static void boot(Loc def_idx) {
 }
 
 // Atomic Linker
-static inline void move(TM *tm, Loc neg_loc, u64 pos);
+static inline void move(TM *tm, Loc neg_loc, Term pos);
+static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl, Term exp_neg);
 
-static inline void link_terms(TM *tm, Term neg, Term pos) {
+static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
-    Term far = swap(term_loc(pos), neg);
+    Loc loc = term_loc(pos);
+    Term far = swap_lvl(loc, neg, lvl);
+    //MLOG_LVL(MOP_EXCH, tm->tid, lvl, loc, far, neg);
     if (term_tag(far) != SUB) {
-      move(tm, term_loc(pos), far);
+      move_lvl(tm, term_loc(pos), far, lvl + 1, neg);
     }
   } else {
     rbag_push(tm, neg, pos);
   }
 }
 
-static inline void move(TM *tm, Loc neg_loc, Term pos) {
-  Term neg = swap(neg_loc, pos);
+static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl, Term exp_neg) {
+  Term neg = swap_lvl(neg_loc, pos, lvl);
+#if 0
+  if ((lvl > 0) && (exp_neg != neg)) {
+    fprintf(stderr, "OOF\n");
+  }
+#endif
+  //MLOG_LVL(MOP_EXCH, tm->tid, lvl, neg_loc, neg, pos);
   if (term_tag(neg) != SUB) {
     // No need to take() since we already swapped
-    link_terms(tm, neg, pos);
+    link_lvl(tm, neg, pos, lvl + 1);
   }
+}
+
+static inline void link_terms(TM *tm, Term neg, Term pos) {
+  link_lvl(tm, neg, pos, 0);
+}
+
+static inline void move(TM *tm, Loc neg_loc, Term pos) {
+  move_lvl(tm, neg_loc, pos, 0, 0);
 }
 
 // Interactions
@@ -1012,8 +1019,16 @@ static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
   Loc ret = port(2, a_loc);
   Loc var = port(1, b_loc);
   Term bod = take(port(2, b_loc));
+
+  bool buse = tm->buse;
+  tm->buse = false;
+  //  tm->muse = true;
+
   move(tm, var, arg);
   move(tm, ret, bod);
+
+  //  tm->muse = false;
+  tm->buse = buse;
 }
 
 static void interact_appsup(TM *tm, Loc a_loc, Loc b_loc) {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 //#define DEBUG
-#define MEMLOG
+//#define MEMLOG
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
@@ -131,7 +131,7 @@ enum : u64 {
   //////////////////////////
   // Choose a heap size here
   //////////////////////////
-  HEAP_SIZE = HEAP_1GB * 4,
+  HEAP_SIZ = HEAP_1GB * 4,
 
   // Cache line size
   CACH_SIZ = 64,
@@ -151,21 +151,21 @@ enum : u64 {
   //////////////////////////
   // Choose a RBAG size here
   //////////////////////////
-  RBAG_SIZE = RBAG_RANDO,
+  RBAG_SIZ = RBAG_RANDO,
 };
 
 enum : u32 {
   // Must of these must be 16-byte aligned (even).
 
   // Final calculated RBAG index
-  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(Term)) & ~1ULL,
+  RBAG = ((HEAP_SIZ - RBAG_SIZ) / sizeof(Term)) & ~1ULL,
 
   // Calculate RBAG_LEN and NODE_LEN: number of terms *per thread*
-  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(Term))) & ~1ULL,
-  NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(Term)),
+  RBAG_LEN = (RBAG_SIZ / (TPC * sizeof(Term))) & ~1ULL,
+  NODE_LEN = (HEAP_SIZ - RBAG_SIZ) / (TPC * sizeof(Term)),
 
   // Booty-bag length.
-  BBAG_LEN = 16,
+  BBAG_LEN = 96,
 
   // Offset in RBAG of overflow bags
   OFLW_INI = (RBAG_LEN - (OFLW_LEN * 2)) & ~1ULL,
@@ -233,7 +233,8 @@ typedef struct TM {
 #endif
 
   bool buse; // can use booty bag
-  bool bful; // ctrl word marked full
+  //bool bful; // ctrl word marked full
+  bool bhld; // booty bag ctrl word is 'HELD'
   u8   opid; // oput idx we are pushing into
   bool ouse; // can use overflow
   bool osyn; // overflow is sync'd
@@ -245,9 +246,11 @@ static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
 
 // Booty bag control word values
 enum : u32 {
-  EMPTY = 0,
-  FULL = 1,
-  STOLEN = 2
+  HELD = 1,    // held by owner
+  DROPPED = 2, // dropped by owner. can be picked back up by owner or stolen
+               // by another thread
+  STOLEN = 3,  // stolen by another thread
+  TOSSED = 4   // emptied by another thread. thief's version of DROPPED.
 };
 
 typedef struct BB {
@@ -492,7 +495,7 @@ static void mlog(u32 tid, u32 mop, Loc loc, Term t1, Term t2, u32 lvl) {
 
 static void mlog_pair(u32 tid, u32 mop, Loc loc, Pair pair) {
   mlog(tid, mop, loc, pair_neg(pair), 0, 0);
-  mlog(tid, mop, loc, pair_pos(pair), 0, 0);
+  mlog(tid, mop, loc+1, pair_pos(pair), 0, 0);
 }
 
 #endif // MEMLOG
@@ -553,7 +556,7 @@ TM *tm_new(u64 tid) {
   tm->oput[0] = 0;
   tm->oput[1] = 0;
   tm->opid = 0;
-  tm->bful = false;
+  tm->bhld = true;
   tm->buse = false;
   tm->ouse = false;
   tm->osyn = false;
@@ -638,8 +641,8 @@ static int mop_debug = 0; // memory operations
 //static int thd_debug = 0; // threading
 #endif
 __attribute__((unused))
-static int bty_debug = 1; // booty bag
-static int oflw_debug = 1; // overflow
+static int bty_debug = 0; // booty bag
+static int oflw_debug = 0; // overflow
 
 __attribute__((unused))
 static const char* term_str(char* buf, Term term) {
@@ -751,6 +754,99 @@ static bool bbag_full(TM *tm) {
   return tm->bput == BBAG_LEN;
 }
 
+static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
+                              memory_order success_order) {
+  return atomic_compare_exchange_strong_explicit(&bbs[tid].ctrl, &expect,
+      desire, success_order, memory_order_relaxed);
+}
+
+static void bbag_set(u32 tid, u32 val, memory_order order) {
+  atomic_store_explicit(&bbs[tid].ctrl, val, order);
+}
+
+__attribute__((unused))
+static u32 bbag_get(u32 tid) {
+  return atomic_load_explicit(&bbs[tid].ctrl, memory_order_relaxed);
+}
+
+static void bbag_drop(TM *tm) {
+  #if 1 || defined(DEBUG)
+  if (bty_debug) {
+    fprintf(stderr, "%u dropping bbag! bput %u rput %u\n", //added %u dexes,
+            tm->tid, tm->bput, tm->rput);
+  }
+  #endif
+
+  // TODO: compare_exchange from STOLEN for added safety
+  bbag_set(tm->tid, DROPPED, memory_order_release);
+  tm->bhld = false;
+}
+
+// attempt to recover a tossed (stolen, and emptied) booty bag
+static bool bbag_recover(TM *tm) {
+  bool held = bbag_compare_swap(tm->tid, TOSSED, HELD, memory_order_relaxed);
+  if (held) {
+    tm->bhld = true;
+    tm->bput = 0;
+
+    #if 1 || defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%u recovered empty stolen bbag!\n", tm->tid);
+    }
+    #endif
+  }
+  return held;
+}
+
+// attempt to pick up our own dropped booty bag. this is actually treated as
+// a form of "stealing" from self. it is the only condition under which popping
+// from our own bag is allowed.
+static bool bbag_pickup(TM *tm) {
+  bool held = bbag_compare_swap(tm->tid, DROPPED, HELD, memory_order_relaxed);
+  if (held) {
+    tm->bhld = true;
+    tm->spop = tm->bput; // will always be BBAG_LEN
+    tm->sid = tm->tid;
+
+    #if 1 || defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%d picked up our own dropped bbag!\n", tm->tid);
+    }
+    #endif
+  }
+  return held;
+}
+
+// attempt to steal another thread's dropped booty bag
+static bool bbag_steal(TM *tm, u32 sid) {
+  bool stole = bbag_compare_swap(sid, DROPPED, STOLEN, memory_order_acquire);
+  if (stole) {
+    tm->spop = BBAG_LEN;
+    tm->sid = sid;
+    
+    #if 1 || defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%d stole t%u's bbag!\n", tm->tid, sid);
+    }
+    #endif
+  }
+  return stole;
+}
+
+// toss the booty bag we stole from another thread and emptied
+static void bbag_toss(TM *tm) {
+  #if 1 || defined(DEBUG)
+  if (bty_debug) {
+    fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n",// removed %u dexes\n",
+            tm->tid, tm->sid);//, tm->srem);
+  }
+  #endif
+
+  // TODO: compare_exchange from STOLEN for added safety
+  bbag_set(tm->sid, TOSSED, memory_order_relaxed);
+  tm->sid = TPC;
+}
+
 static Loc rbag_ini(u32 tid) {
   return bbag_ini(tid) + BBAG_LEN;
 }
@@ -801,20 +897,6 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   return loc;
 }
 
-static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
-                              memory_order success_order) {
-  return atomic_compare_exchange_strong_explicit(&bbs[tid].ctrl, &expect,
-      desire, success_order, memory_order_relaxed);
-}
-
-static void bbag_set(u32 tid, u32 val, memory_order order) {
-  atomic_store_explicit(&bbs[tid].ctrl, val, order);
-}
-
-static u32 bbag_get(u32 tid) {
-  return atomic_load_explicit(&bbs[tid].ctrl, memory_order_relaxed);
-}
-
 static Loc get_push_offset(TM *tm, bool force_oflw) {
   if (force_oflw && tm->ouse) {
     #if defined(DEBUG)
@@ -824,18 +906,22 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
     }
     #endif
 
-    return oflw_offset(tm->opid) + tm->oput[tm->opid];
+    u32 oput = tm->oput[tm->opid];
+    tm->oput[tm->opid] += 2;
+    return oflw_offset(tm->opid) + oput;
   }
 
   // Only push to booty bag if we aren't stealing
-  if (tm->buse && !tm->bful && !bbag_full(tm) && (tm->sid == TPC)) {
+  if (tm->buse && tm->bhld && !bbag_full(tm) && (tm->sid == TPC)) {
     #if defined(DEBUG)
     if (bty_debug) {
       fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
     }
     #endif
 
-    return tm->bput;
+    u32 bput = tm->bput;
+    tm->bput += 2;
+    return bput;
   }
 
   #if 0 && defined(DEBUG)
@@ -843,7 +929,9 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
           tm->rput, (u32)tm->buse);
   #endif
   // Push to RBAG
-  return BBAG_LEN + tm->rput;
+  u32 rput = tm->rput;
+  tm->rput += 2;
+  return BBAG_LEN + rput;
 }
 
 static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
@@ -861,25 +949,23 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
   set_pair(loc, pair_new(neg, pos));
 
   // TODO: adjust_put_idx(tm, off);
-  if (off < BBAG_LEN) {
-    // pushed to booty bag
-    tm->bput += 2;
-  } else if (off >= OFLW_INI) {
+
+#if 1
+  if (off >= OFLW_INI) {
     // pushed to overflow
     if (tm->oput[tm->opid] >= OFLW_LEN-1) {
       fprintf(stderr, "%u overflow %u space exhausted @ %u\n", tm->tid,
               tm->opid, tm->oput[tm->opid]);
       exit(1);
     }
-    tm->oput[tm->opid] += 2;
-  } else {
+  } else if (off > BBAG_LEN) {
     // pushed to RBAG
     if (tm->rput >= RPUT_MAX-1) {
       fprintf(stderr, "%u rbag space exhausted\n", tm->tid);
       exit(1);
     }
-    tm->rput += 2;
   }
+#endif
 }
 
 _Thread_local u64 noflw = 0;
@@ -918,8 +1004,9 @@ static Loc redex_pop_loc(TM* tm) {
 #endif
   }
     
-  if (tm->spop > 0) {
-    // Pop from stolen, non-empty booty bag
+  if ((tm->sid < TPC) && (tm->spop > 0)) {
+    // Pop from stolen non-empty booty bag - but we could have 'stolen' our
+    // own HELD bag.
     tm->spop -= 2;
 
     // If we are stealing from our own booty bag, adjust push index as well
@@ -938,9 +1025,9 @@ static Loc redex_pop_loc(TM* tm) {
     // Pop from non-empty RBAG
     tm->rput -= 2;
 
-#if 0 && defined(DEBUG)
+    #if 0 && defined(DEBUG)
     fprintf(stderr, "%u popping from RBAG @ %u\n", tm->tid, tm->rput);
-#endif
+    #endif
 
     return rbag_ini(tm->tid) + tm->rput;
   } else {
@@ -952,22 +1039,25 @@ static Loc redex_pop_loc(TM* tm) {
 // FFI functions
 void hvm_init() {
   if (BUFF == NULL) {
-    BUFF = aligned_alloc(CACH_SIZ, HEAP_SIZE);
+    BUFF = aligned_alloc(CACH_SIZ, HEAP_SIZ);
     if (BUFF == NULL) {
       fprintf(stderr, "Heap memory allocation failed\n");
       exit(EXIT_FAILURE);
     }
   }
-  memset(BUFF, 0, HEAP_SIZE);
+  memset(BUFF, 0, HEAP_SIZ);
 
   alloc_static_data();
 
-  #if 0 
-  fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
-  fprintf(stderr, "RBAG_SIZE = %" PRIu64 "\n", RBAG_SIZE);
-  fprintf(stderr, "RBAG      = %u\n", RBAG);
-  fprintf(stderr, "RBAG_LEN  = %u\n", RBAG_LEN);
-  fprintf(stderr, "NODE_LEN  = %u\n", NODE_LEN);
+  #if 1
+  fprintf(stderr, "HEAP_SIZ = %" PRIu64 "\n", HEAP_SIZ);
+  fprintf(stderr, "RBAG_SIZ = %" PRIu64 "\n", RBAG_SIZ);
+  fprintf(stderr, "RBAG     = %u\n", RBAG);
+  fprintf(stderr, "RBAG_LEN = %u\n", RBAG_LEN);
+  fprintf(stderr, "NODE_LEN = %u\n", NODE_LEN);
+  fprintf(stderr, "BBAG_LEN = %u\n", BBAG_LEN);
+  fprintf(stderr, "OFLW_INI = %u\n", OFLW_INI);
+  fprintf(stderr, "OFLW_LEN = %" PRIu64 "\n", OFLW_LEN);
   #endif
 
   signal(SIGSEGV, segv_handler);
@@ -1815,10 +1905,10 @@ static bool sequential_step(TM* tm) {
   return true;
 }
  
-// don't allow idling if our booty bag is marked full (stealable)
+// don't allow idling if our booty bag isn't held
 // because it introduces weirdness that's easier to just ignore for now
 static bool can_idle(TM *tm) {
-  return oflw_empty(tm) && rbag_empty(tm) && bbag_empty(tm) && !tm->bful;
+  return oflw_empty(tm) && rbag_empty(tm) && bbag_empty(tm) && tm->bhld;
 }
  
 static bool set_idle(bool was_busy) {
@@ -1843,53 +1933,31 @@ static bool try_steal(TM *tm) {
   if (!tm->buse) return false;
 
   if (tm->bput > 0) {
-    // Either our booty bag has something in it, or it was stolen and
-    // it had something in it when we dropped it.
-    if (!tm->bful) {
-      // We're holding it, so we can steal without atomics
+    // Either our booty bag has something in it, or it had something in it
+    // and we dropped it.
+    if (tm->bhld) {
+      // We're holding it, so we can "steal" (from) it without atomics
       tm->spop = tm->bput;
       tm->sid = tm->tid;
 
       #if 1 || defined(DEBUG)
       if (bty_debug) {
-        fprintf(stderr, "%u stealing own non-full booty bag\n", tm->tid);
+        fprintf(stderr, "%u stealing from own held bbag!\n", tm->tid);
       }
       #endif
       return true;
     } else {
-      // Try to pick up our dropped bag - only works if nobody stole it.
-      if (bbag_compare_swap(tm->tid, FULL, EMPTY, memory_order_relaxed)) {
-        tm->bful = false;
-        tm->spop = tm->bput; // will always be BBAG_LEN
-        tm->sid = tm->tid;
-
-        #if 1 || defined(DEBUG)
-        if (bty_debug) {
-          fprintf(stderr, "%u stole own full booty bag\n", tm->tid);
-        }
-        #endif
+      if (bbag_pickup(tm)) {
         return true;
       }
     }
   }
-
-  // Our booty bag is either empty, or another thread stole it.
-  // Try to steal another thread's full bag
-  u32 vic = get_victim(tm);
-  if (bbag_compare_swap(vic, FULL, STOLEN, memory_order_acquire)) {
-    tm->spop = BBAG_LEN;
-    tm->sid = vic;
+  // Our booty bag is either empty, or another thread stole it - try to steal
+  // another thread's full bag
+  if (bbag_steal(tm, get_victim(tm))) {
     tm->sgud += 1;
-
-    #ifdef DEBUG
-    if (bty_debug) {
-      fprintf(stderr, "%u stole t%u's booty bag\n", tm->tid, tm->sid);
-    }
-    #endif
-
     return true;
   }
-
   tm->sbad += 1;
   return false;
 }
@@ -1906,20 +1974,12 @@ static bool timeout(u64 tick) {
   return false;
 }
 
-//static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
 static bool lala_and_interact(TM *tm, Pair pair, bool from_bty) {
-  // TODO just absolutely intolerable hack
-  if (from_bty && (tm->spop == 0)) {
+  if ((tm->sid < TPC) && (tm->spop == 0)) {
     // The booty bag we stole just became empty
     if (tm->sid != tm->tid) {
-      // It was another threads bag - signal that it can be recovered now
-      bbag_set(tm->sid, EMPTY, memory_order_relaxed);
-
-      #if defined(DEBUG)
-      if (bty_debug) {
-        fprintf(stderr, "%u emptied t%u's stolen booty bag\n", tm->tid, tm->sid);
-      }
-      #endif
+      // It was another threads bag - toss it
+      bbag_toss(tm);
     } else {
       #if 1 || defined(DEBUG)
       if (bty_debug) {
@@ -1927,7 +1987,6 @@ static bool lala_and_interact(TM *tm, Pair pair, bool from_bty) {
       }
       #endif
     }
-
     // No longer stealing
     tm->sid = TPC;
   }
@@ -2040,21 +2099,16 @@ static bool sync_wait_departures() {
 
 #define SYNC_REQ_SIZE 1024
 
-// more booty bag 'marked full' weirdness i'm trying to bicycle around
-// allow sync requests if booty bag appears non-empty, if it's been marked
-// full
+// more booty bag 'HELD' weirdness i'm trying to bicycle around. allow sync
+// sync requests if booty bag appears non-empty, if it's not held
 static bool request_sync(TM *tm) {
   Loc oput = tm->oput[tm->opid];
   bool req = (oput >= SYNC_REQ_SIZE) ||
-    ((oput > 0) && rbag_empty(tm) && (bbag_empty(tm) || tm->bful));
+    ((oput > 0) && rbag_empty(tm) && (bbag_empty(tm) || !tm->bhld));
   if (req) {
-    //sync_add_request();
-    
     if (oflw_debug) {
-      fprintf(stderr, "%u requesting sync \n", // @ %u, stop taking from overflow %u len %u\n",
-              tm->tid); // , nsync+1, 1u-tm->opid, tm->oput[1u-tm->opid]/2);
+      fprintf(stderr, "%u requesting sync\n", tm->tid);
     }
-
   }
   return req;
 }
@@ -2083,6 +2137,8 @@ static void* thread_func(void* arg) {
   bool all_arrived = false;
   bool syncing = false;
   u64 do_nothing = 0;
+
+  __attribute__((unused))
   u64 last_work_tick = 0;
 
   u64  tick = 0;
@@ -2094,11 +2150,13 @@ static void* thread_func(void* arg) {
 
     tick += 1;
 
+#if 0
     if (busy && ((tick - last_work_tick) % 65536 == 0)) {
-      fprintf(stderr, "%u busy doing nothing syncing %u osyn %u bbag %u bful %u stolen %u rbag %u oflw %u oflw_other %u\n",
-              tm->tid, (u32) syncing, (u32)tm->osyn, tm->bput, (u32) tm->bful, (u32)(tm->sid < TPC),
+      fprintf(stderr, "%u busy doing nothing syncing %u osyn %u bbag %u bhld %u stolen %u rbag %u oflw %u oflw_other %u\n",
+              tm->tid, (u32) syncing, (u32)tm->osyn, tm->bput, (u32) tm->bhld, (u32)(tm->sid < TPC),
               tm->rput, tm->oput[tm->opid], tm->oput[1-tm->opid]);
     }
+#endif
 
     if (tm->ouse) {
       if (!syncing) {
@@ -2148,6 +2206,11 @@ static void* thread_func(void* arg) {
       }
     }
 
+    // Try to recover stolen and emptied booty bag
+    if (!tm->bhld) {
+      bbag_recover(tm);
+    }
+
     // much hax
     u32 oidx = 1u-tm->opid;
     u32 oput = tm->oput[oidx];
@@ -2159,16 +2222,6 @@ static void* thread_func(void* arg) {
       last_work_tick = 0;
 
       busy = set_busy(busy);
-
-      // We *think* booty bag is full, but it may have been stolen and emptied
-      if (tm->bful && (bbag_get(tm->tid) == EMPTY)) {
-        tm->bful = false;
-        tm->bput = 0;
-
-        #ifdef DEBUG
-        fprintf(stderr, "%u recovered stolen, empty booty bag\n", tm->tid);
-        #endif
-      }
 
       Pair pair = take_pair(loc, from_bty);
       if (!lala_and_interact(tm, pair, from_bty)) {
@@ -2183,11 +2236,10 @@ static void* thread_func(void* arg) {
         }
       }
 
-      if (!tm->bful && bbag_full(tm)) {
-        // Booty bag is full, but hasn't been marked full
+      if (tm->bhld && (tm->sid == TPC) && bbag_full(tm)) {
+        // We're holding a full, non-stolen booty bag. Consider dropping it.
         if (!rbag_empty(tm)) { //|| !oflw_empty(tm)) {
-          bbag_set(tm->tid, FULL, memory_order_release);
-          tm->bful = true;
+          bbag_drop(tm);
         }
       }
     } else {
@@ -2305,10 +2357,11 @@ static char *tag_to_str(Tag tag) {
 __attribute__((unused))
 static char *bty_ctrl_str(u32 ctrl) {
   switch (ctrl) {
-  case EMPTY:  return "EMPTY";
-  case FULL:   return "FULL";
-  case STOLEN: return "STOLEN";
-  default:     return "???";
+  case HELD:    return "HELD";
+  case DROPPED: return "DROPPED";
+  case STOLEN:  return "STOLEN";
+  case TOSSED:  return "TOSSED";
+  default:      return "???";
   }
 }
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -996,7 +996,9 @@ static Loc oflw_pop_loc(TM *tm) {
 }
 
 static void oflw_sync(TM *tm) {
+#ifdef __APPLE__
   dmb_ishst();
+#endif
   tm->opid = 1u - tm->opid;
   tm->osyn = true;
 }

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -16,8 +16,7 @@
 #include <string.h>
 #include <unistd.h>
 
-//#define SUMMARY
-
+#define SUMMARY
 //#define DEBUG
 //#define VOIDTEST
 
@@ -38,13 +37,8 @@ void exit_stacktrace() {
 }
 
 void segv_handler(int sig) {
-  void *array[10];
-  size_t size;
-  
-  size = backtrace(array, 10);
   fprintf(stderr, "Error: signal %d:\n", sig);
-  backtrace_symbols_fd(array, size, STDERR_FILENO);
-  exit(1);
+  exit_stacktrace();
 }
 
 #ifdef __APPLE__
@@ -59,6 +53,7 @@ __asm__(
     "   ret\n"
 );
 
+// Store barrier
 extern void dmb_ishst(void);
 __asm__(
     ".global dmb_ishst\n"
@@ -68,7 +63,7 @@ __asm__(
     "    dmb ishst\n"
     "    ret\n"
 );
-#endif
+#endif // __APPLE__
 
 // Constants
 #define VAR 0x01
@@ -129,9 +124,6 @@ typedef union {
   f32 f;
 } TypeConverter;
 
-// Global heap
-static u64 *BUFF = NULL;
-
 // Heap configuration options
 enum : u64 {
   // 1GiB heap
@@ -145,21 +137,32 @@ enum : u64 {
   // Cache line size
   CACH_SIZ = 64,
   CACH_U64 = CACH_SIZ / sizeof(u64),
-  ZERO = 0,
 
   // Threads per CPU
   TPC = 10,
 
-  // Overflow bag terms per thread (there are 2 bags)
-  OFLW_LEN = 256,
-  // When overflow bag gets this big, a memory sync occurs
-  OFLW_SYNC = 32,
+#ifdef __APPLE__
+  // PCores and ECores total, and in-use
+  PCOR_TOT = 4,
+  ECOR_TOT = TPC - PCOR_TOT,
+  PCOR = TPC < PCOR_TOT ? TPC : PCOR_TOT,
+  ECOR = TPC > PCOR_TOT ? (TPC - PCOR) : 0,
+#endif
 
-  // Includes overflow and BBAG
-  RBAG_RANDO = 8192 * TPC * sizeof(Pair),
+  // Misc
+  ZERO = 0,
+  IDLE = 256,
+
+  // Deferred bag terms per thread (2 bags: twice this len used)
+  DFER_LEN = 256,
+  // When deferred bag gets this big, a memory sync occurs
+  DFER_SYN = 32,
+
+  // Includes booty and deferred bags
+  RBAG_QED = 8192 * TPC * sizeof(Pair), // Demonstrated to work
 
   // Used in other calculations below
-  RBAG_SIZ = RBAG_RANDO,
+  RBAG_SIZ = RBAG_QED,
 };
 
 enum : u32 {
@@ -172,20 +175,18 @@ enum : u32 {
   RBAG_LEN = (RBAG_SIZ / (TPC * sizeof(Term))) & ~1ULL,
   NODE_LEN = (HEAP_SIZ - RBAG_SIZ) / (TPC * sizeof(Term)),
 
-  // Booty bag terms per thread
+  // Booty bag terms per thread (also starting offset of RBAG)
   BBAG_LEN = 96,
 
-  // Starting offset in RBAG of overflow bags
-  OFLW_INI = (RBAG_LEN - (OFLW_LEN * 2)) & ~1ULL,
+  // Starting offset of deferred bags
+  DFER_INI = (RBAG_LEN - (DFER_LEN * 2)) & ~1ULL,
 
-  // Max terms allowed in RBAG, taking into account booty bag and overflow
-  RPUT_MAX = OFLW_INI - BBAG_LEN
+  // Max terms allowed in RBAG, taking into account booty and deferred bags
+  RPUT_MAX = DFER_INI - BBAG_LEN
 };
 
 typedef struct Net {
-  a64 nods;
-  a64 itrs;
-  a32 alignas(64) idle;  // TODO Probably should just make it a64
+  a64 idle;
 } Net;
 
 // Global book
@@ -203,21 +204,6 @@ typedef struct Book {
   u32 cap;
 } Book;
 
-// TODO: net_reset()
-static Net net = {
-  .nods = 0,
-  .itrs = 0,
-  .idle = 0
-};
-
-static Book BOOK = {
-  .defs = NULL,
-  .len = 0,
-  .cap = 0,
-};
-
-#define MBUF_SIZ 10
-
 // Local Thread Memory
 typedef struct TM {
   u32 tid;   // thread id
@@ -230,15 +216,24 @@ typedef struct TM {
   u32 sgud;  // successful steal count
   u32 sbad;  // failed steal count
 
-  Loc oput[2]; // next oflw bag push indices
+  Loc dput[2]; // next deferred bag push indices
   
+  uint16_t scnt;
+  uint16_t smax;
+  uint16_t stot;
+  uint16_t smsk;
+
   bool buse; // can use booty bag
   bool bhld; // when we KNOW booty bag ctrl word is HELD
              // (in some cases it may be HELD but we don't know)
 
-  u8   opid; // oput idx we are pushing into
-  bool ouse; // can use overflow
-  bool osyn; // overflow is sync'd
+  u8   dpid; // dput idx we are pushing into
+  bool duse; // can use deferred bag
+  bool dsyn; // deferred bag is sync'd
+
+  u8   lvic;
+  u8   pvic;
+  u8   evic;
 
   u64 itrs;  // interaction count
 } TM;
@@ -246,16 +241,25 @@ typedef struct TM {
 static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
 
 // Booty bag control word values
-enum : u32 {
-  HELD = 1,    // held by owner, or "tossed" by another thread
-  DROPPED = 2, // dropped by owner. can be picked back up by owner
-               // or stolen by another thread
+enum : u64 {
+  HELD = 1,    // held by owner, or "returned" by another thread
+  DROPPED = 2, // dropped by owner. can be picked back up by owner or stolen
+               // by another thread
   STOLEN = 3,  // stolen by another thread
 };
 
 typedef struct BB {
-  a32 alignas(64) ctrl; // control word TODO: just make it a64
+  a64 ctrl; // control word
 } BB;
+
+// Global heap, net, book
+static u64 *BUFF = NULL;
+static Net net;
+static Book BOOK = {
+  .defs = NULL,
+  .len = 0,
+  .cap = 0,
+};
 
 static TM *tms[TPC];
 static BB bbs[TPC];
@@ -268,23 +272,20 @@ static _Thread_local int thread_id = 0;
 
 // Debugging
 static char *tag_to_str(Tag tag);
-
-static Term pair_pos(Pair pair);
-static Term pair_neg(Pair pair);
 static const char* term_str(char* buf, Term term);
+
+__attribute__((unused))
+static int bty_debug = 0; // booty bag
+__attribute__((unused))
+static int dfer_debug = 0; // deferred bag
 
 // FFI functions
 void dump_buff();
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
-static u32 u64_hi(u64 e) {
-  return e >> 32;
-}
-
-__attribute((unused))
-static u32 u64_lo(u64 e) {
-  return e & 0xFFFFFFFF;
+static u64 align(u64 align, u64 val) {
+  return (val + align - 1) & ~(align - 1);
 }
 
 // TM/BB operations
@@ -296,27 +297,42 @@ void tm_reset(TM *tm) {
 
 TM *tm_new(u64 tid) {
   // make size a multiple of alignment
-  size_t tm_siz = (sizeof(TM) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
-  TM *tm = aligned_alloc(CACH_SIZ, tm_siz);
+  TM *tm = aligned_alloc(CACH_SIZ, align(CACH_SIZ, sizeof(TM)));
   if (tm == NULL) {
-    fprintf(stderr, "TM memory allocation failed\n");
-    exit(EXIT_FAILURE);
+    fprintf(stderr, "tm_new() memory allocation failed\n");
+    exit(1);
   }
   tm_reset(tm);
+
   tm->tid = tid;
+
+  // Booty bag
   tm->bput = 0;
-  tm->spop = 0;
-  tm->sid = TPC;
-  tm->sgud = 0;
-  tm->sbad = 0;
   tm->bhld = true;
   tm->buse = false;
 
-  tm->oput[0] = 0;
-  tm->oput[1] = 0;
-  tm->opid = 0;
-  tm->ouse = false;
-  tm->osyn = false;
+  // Stolen booty bag
+  tm->sid = TPC;
+  tm->spop = 0;
+  tm->sgud = 0;
+  tm->sbad = 0;
+
+  // Deferred bag
+  tm->dput[0] = 0;
+  tm->dput[1] = 0;
+  tm->dpid = 0;
+  tm->duse = false;
+  tm->dsyn = false;
+
+  // Last steal attempt thread ids
+  tm->lvic = TPC;
+  tm->pvic = tid % PCOR;
+  tm->evic = (tid % ECOR) + PCOR;
+
+  tm->scnt = 0;
+  tm->smax = 0;
+  tm->stot = 0;
+  tm->smsk = 0;
 
   return tm;
 }
@@ -333,12 +349,6 @@ static void free_static_data() {
       free(tms[t]);
       tms[t] = NULL;
     }
-    #if 0
-    if (bbs[t] != NULL) {
-      free(bbs[t]);
-      bbs[t] = NULL;
-    }
-    #endif
   }
 }
 
@@ -362,7 +372,7 @@ Term term_new(Tag tag, Lab lab, Loc loc) {
 
 Lab term_lab(Term term) { return (term >> 8) & 0xFFFFFF; }
 
-Loc term_loc(Term term) { return u64_hi(term); }
+Loc term_loc(Term term) { return term >> 32; }
 
 static Term term_with_loc(Term term, Loc loc) {
   return (((Term)loc) << 32) | (term & 0xFFFFFFFF);
@@ -379,20 +389,10 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
-__attribute__((unused))
-static int bty_debug = 0; // booty bag
-__attribute__((unused))
-static int oflw_debug = 0; // overflow
-
-__attribute__((unused))
-static const char* term_str(char* buf, Term term) {
-  snprintf(buf, 64, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
-          (u32)term_lab(term), (u32)term_loc(term));
-  return buf;
-}
+static Loc port(u32 n, Loc loc) { return n + loc - 1; }
 
 // Memory operations
-Term swap_lvl(Loc loc, Term term, u32 lvl) {
+Term swap(Loc loc, Term term) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
 
   #ifdef VOIDTEST
@@ -402,10 +402,6 @@ Term swap_lvl(Loc loc, Term term, u32 lvl) {
   }
   #endif
   return got;
-}
-
-Term swap(Loc loc, Term term) {
-  return swap_lvl(loc, term, 0);
 }
 
 Term take(Loc loc) {
@@ -427,7 +423,6 @@ Term get(Loc loc) {
 
 void set(Loc loc, Term term) {
   atomic_store_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
-
 }
 
 static Pair take_pair(Loc loc) {
@@ -460,8 +455,6 @@ static void set_pair(Loc loc, Pair pair) {
   *((Pair*)&BUFF[loc]) = pair;
 }
 
-static Loc port(u64 n, Loc loc) { return n + loc - 1; }
-
 static Loc bbag_offset(u32 tid) {
   return tid * RBAG_LEN;
 }
@@ -478,7 +471,7 @@ static bool bbag_full(TM *tm) {
   return tm->bput == BBAG_LEN;
 }
 
-static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
+static bool bbag_compare_swap(u32 tid, u64 expect, u32 desire,
                               memory_order success_order) {
   return atomic_compare_exchange_strong_explicit(&bbs[tid].ctrl, &expect,
       desire, success_order, memory_order_relaxed);
@@ -505,7 +498,7 @@ static void bbag_drop(TM *tm) {
   tm->bhld = false;
 }
 
-// Attempt to recover a tossed (stolen, and emptied) booty bag
+// Attempt to recover a stolen and emptied booty bag
 static bool bbag_recover(TM *tm) {
   bool held = bbag_get(tm->tid) == HELD;
   if (held) {
@@ -555,15 +548,32 @@ static bool bbag_steal(TM *tm, u32 sid) {
   return stole;
 }
 
-// Toss the booty bag we stole from another thread and emptied
-static void bbag_toss(TM *tm) {
-  #if defined(DEBUG)
-  if (bty_debug) {
-    fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n", tm->tid, tm->sid);
-  }
-  #endif
+// Return true if booty bag is stolen, and empty
+static bool bbag_looted(TM *tm) {
+  return (tm->sid < TPC) && (tm->spop == 0);
+}
 
-  bbag_set(tm->sid, HELD, memory_order_relaxed);
+// Return a stolen, empty booty bag:
+// * if it was stolen stolen from another thread, mark it HELD
+// * reset tm->sid to indicate we're no longer stealing
+static void bbag_return(TM *tm) {
+  if (tm->sid != tm->tid) {
+    // It was another threads bag - reset state to HELD
+    bbag_set(tm->sid, HELD, memory_order_relaxed);
+    
+    #if defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%u tossing t%u's empty stolen bbag!\n", tm->tid, tm->sid);
+    }
+    #endif
+  } else {
+    #if 0 || defined(DEBUG)
+    if (bty_debug) {
+      fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
+    }
+    #endif
+  }
+  // No longer stealing
   tm->sid = TPC;
 }
 
@@ -579,24 +589,27 @@ static Loc rnod_ini(u32 tid) {
   return tid * NODE_LEN;
 }
 
-static Loc oflw_offset(u32 oidx) {
-  return OFLW_INI + OFLW_LEN * oidx;
+static Loc dfer_offset(u32 idx) {
+  return DFER_INI + DFER_LEN * idx;
 }
 
-static Loc oflw_ini(u32 tid, u32 oidx) {
-  return bbag_ini(tid) + oflw_offset(oidx);
+static Loc dfer_ini(u32 tid, u32 idx) {
+  return bbag_ini(tid) + dfer_offset(idx);
 }
 
-static bool oflw_empty(TM *tm) {
-  return (tm->oput[0] == 0) && (tm->oput[1] == 0);
+// Check if the sync'd deferred bag we might pop from is empty
+__attribute__((unused))
+static bool dfer_empty(TM *tm) {
+  return tm->dput[1u-tm->dpid] == 0;
+}  
+
+// Check if there are any items in either deferred bag
+static bool dfer_any(TM *tm) {
+  return (tm->dput[0] > 0) || (tm->dput[1] > 0);
 }  
 
 // Allocator
 // ---------
-
-static u64 align(u64 align, u64 val) {
-  return (val + align - 1) & ~(align - 1);
-}
 
 static Loc node_alloc(TM *tm, u32 cnt) {
   if (tm->nput + cnt >= NODE_LEN) {
@@ -610,18 +623,18 @@ static Loc node_alloc(TM *tm, u32 cnt) {
   return loc;
 }
 
-static Loc get_push_offset(TM *tm, bool force_oflw) {
-  if (force_oflw && tm->ouse) {
+static Loc get_push_offset(TM *tm, bool dfer) {
+  if (dfer && tm->duse) {
     #if defined(DEBUG)
-    if (oflw_debug) {
-      fprintf(stderr, "%u pushing to overflow %u @ %u\n", tm->tid,
-            0u+tm->opid, tm->oput[tm->opid]);
+    if (dfer_debug) {
+      fprintf(stderr, "%u pushing to deferred %u @ %u\n", tm->tid,
+            0u+tm->dpid, tm->dput[tm->dpid]);
     }
     #endif
 
-    u32 oput = tm->oput[tm->opid];
-    tm->oput[tm->opid] += 2;
-    return oflw_offset(tm->opid) + oput;
+    u32 dput = tm->dput[tm->dpid];
+    tm->dput[tm->dpid] += 2;
+    return dfer_offset(tm->dpid) + dput;
   }
 
   // Only push to booty bag if we aren't stealing
@@ -647,18 +660,29 @@ static Loc get_push_offset(TM *tm, bool force_oflw) {
   return BBAG_LEN + rput;
 }
 
-static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
+static void redex_push(TM *tm, Term neg, Term pos, bool dfer) {
   #ifdef VOIDTEST
   if ((neg == 0) || (pos == 0)) {
-    fprintf(stderr, "%d rbag_push: void term\n", thread_id);
+    fprintf(stderr, "%d redex_push: void term\n", thread_id);
     exit_stacktrace();
   }
   #endif
 
-  Loc off = get_push_offset(tm, force_oflw);
+  Loc off = get_push_offset(tm, dfer);
   Loc loc = bbag_ini(tm->tid) + off;
 
   set_pair(loc, pair_new(neg, pos));
+
+  if (off < BBAG_LEN) {
+    // We pushed to booty bag
+    if (bbag_full(tm)) {
+      // We're holding a full, non-stolen booty bag - if there are terms in
+      // other bags available to pop immediately, drop it
+      if (!rbag_empty(tm) || dfer_any(tm)) {
+        bbag_drop(tm);
+      }
+    }
+  }
 
   #ifdef DEBUG
   if (off > BBAG_LEN) {
@@ -671,54 +695,55 @@ static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
   #endif
 }
 
-_Thread_local u64 noflw = 0;
+//_Thread_local u64 noflw = 0;
 
-static Loc oflw_pop_loc(TM *tm) {
-  if (tm->osyn) {
-    // Overflow is sync'd so we can pop
-    u32 oidx = 1u - tm->opid;
-    if (tm->oput[oidx] > 0) {
-      tm->oput[oidx] -= 2;
+static Loc dfer_pop_loc(TM *tm) {
+  if (tm->dsyn) {
+    // Deferred bag is sync'd so we can pop
+    u32 dpid = 1u - tm->dpid;
+    if (tm->dput[dpid] > 0) {
+      tm->dput[dpid] -= 2;
       
       #if defined(DEBUG)
-      if (oflw_debug) {
-        fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
-                oidx, tm->oput[oidx]);
+      if (dfer_debug) {
+        fprintf(stderr, "%u popping from deferred %u @ %u\n", tm->tid,
+                dpid, tm->dput[dpid]);
       }
       #endif
-      ++noflw;
+      //++noflw;
       
-      return oflw_ini(tm->tid, oidx) + tm->oput[oidx];
+      return dfer_ini(tm->tid, dpid) + tm->dput[dpid];
     } else {
-      tm->osyn = false;
+      tm->dsyn = false;
     }
   }
   return 0;
 }
 
-static void oflw_sync(TM *tm) {
+static void dfer_sync(TM *tm) {
 #ifdef __APPLE__
   dmb_ishst();
-#endif
-  tm->opid = 1u - tm->opid;
-  tm->osyn = true;
+#endif // __APPLE__
+  tm->dpid = 1u - tm->dpid;
+  tm->dsyn = true;
 }
 
 static Loc redex_pop_loc(TM* tm) {
-  // Check overflow bag first when sync'd
-  if (tm->ouse) {
-    Loc loc = oflw_pop_loc(tm);
+  // Check deferred bags first
+  if (tm->duse) {
+    Loc loc = dfer_pop_loc(tm);
     if (loc > 0) return loc;
 
-    if (tm->oput[tm->opid] > OFLW_SYNC) {
-      oflw_sync(tm);
-      Loc loc = oflw_pop_loc(tm);
+    // Flip & sync deferred bag if size has reached threshold
+    if (tm->dput[tm->dpid] > DFER_SYN) {
+      dfer_sync(tm);
+      Loc loc = dfer_pop_loc(tm);
       if (loc > 0) return loc;
     }
   }
     
   if ((tm->sid < TPC) && (tm->spop > 0)) {
-    // Pop from stolen non-empty booty bag - but it may be our HELD bag
+    // Pop from stolen booty bag - it may be our HELD bag
     tm->spop -= 2;
 
     // If we are stealing from our own bag, adjust push index as well
@@ -734,7 +759,7 @@ static Loc redex_pop_loc(TM* tm) {
 
     return bbag_ini(tm->sid) + tm->spop;
   } else if (tm->rput > 0) {
-    // Pop from non-empty RBAG
+    // Pop from RBAG
     tm->rput -= 2;
 
     #if 0 && defined(DEBUG)
@@ -742,12 +767,11 @@ static Loc redex_pop_loc(TM* tm) {
     #endif
 
     return rbag_ini(tm->tid) + tm->rput;
-  } else if (tm->ouse) {
-    // Finally, try a flip & sync of overflow bags
-    if (tm->oput[tm->opid] > 0) {
-      oflw_sync(tm);
-      Loc loc = oflw_pop_loc(tm);
-      if (loc > 0) return loc;
+  } else if (tm->duse) {
+    // Finally, try a flip & sync deferred bag with *any* elems
+    if (tm->dput[tm->dpid] > 0) {
+      dfer_sync(tm);
+      return dfer_pop_loc(tm);
     }
   }
   // Steal from someone else
@@ -760,22 +784,22 @@ void hvm_init() {
     BUFF = aligned_alloc(CACH_SIZ, HEAP_SIZ);
     if (BUFF == NULL) {
       fprintf(stderr, "Heap memory allocation failed\n");
-      exit(EXIT_FAILURE);
+      exit(1);
     }
   }
   memset(BUFF, 0, HEAP_SIZ);
 
   alloc_static_data();
 
-  #if 1
+  #ifdef SUMMARY
   fprintf(stderr, "HEAP_SIZ = %" PRIu64 "\n", HEAP_SIZ);
   fprintf(stderr, "RBAG_SIZ = %" PRIu64 "\n", RBAG_SIZ);
   fprintf(stderr, "RBAG     = %u\n", RBAG);
   fprintf(stderr, "RBAG_LEN = %u\n", RBAG_LEN);
   fprintf(stderr, "NODE_LEN = %u\n", NODE_LEN);
   fprintf(stderr, "BBAG_LEN = %u\n", BBAG_LEN);
-  fprintf(stderr, "OFLW_INI = %u\n", OFLW_INI);
-  fprintf(stderr, "OFLW_LEN = %" PRIu64 "\n", OFLW_LEN);
+  fprintf(stderr, "DFER_INI = %u\n", DFER_INI);
+  fprintf(stderr, "DFER_LEN = %" PRIu64 "\n", DFER_LEN);
   #endif
 
   #ifdef DEBUG
@@ -799,7 +823,7 @@ Loc ffi_alloc_node(u64 arity) {
 }
 
 void ffi_rbag_push(Term neg, Term pos) {
-  rbag_push(tms[0], neg, pos, false);
+  redex_push(tms[0], neg, pos, false);
 }
 
 u64 inc_itr() {
@@ -845,27 +869,27 @@ void def_new(char *name) {
   Loc rnod_cnt = tm->nput;
   Loc rbag_cnt = tm->rput;
 
-  u64 rbag_siz = align(CACH_SIZ, sizeof(Term) * rbag_cnt);
-  u64 rnod_siz = align(CACH_SIZ, sizeof(Term) * rnod_cnt);
+  u64 rbag_siz = sizeof(Term) * rbag_cnt;
+  u64 rnod_siz = sizeof(Term) * rnod_cnt;
 
   Def def = {
       .name = name,
-      .nodes = aligned_alloc(CACH_SIZ, rnod_siz),
+      .nodes = aligned_alloc(CACH_SIZ, align(CACH_SIZ, rnod_siz)),
       .nodes_len = rnod_cnt,
-      .rbag = aligned_alloc(CACH_SIZ, rbag_siz),
+      .rbag = aligned_alloc(CACH_SIZ, align(CACH_SIZ, rbag_siz)),
       .rbag_len = rbag_cnt,
   };
 
   if ((def.nodes == NULL) || (def.rbag == NULL)) {
-    fprintf(stderr, "DEF memory allocation failed\n");
+    fprintf(stderr, "def_new() memory allocation failed\n");
     exit(1);
   }
 
-  Term *nodes = BUFF;
+  Term *rnod = BUFF;
   Term *rbag = &BUFF[rbag_ini(0)];
 
-  memcpy(def.nodes, nodes, sizeof(Term) * def.nodes_len);
-  memcpy(def.rbag, rbag, sizeof(Term) * def.rbag_len);
+  memcpy(def.nodes, rnod, rnod_siz);
+  memcpy(def.rbag, rbag, rbag_siz);
 
   #if 0
   printf("NEW DEF '%s':\n", def.name);
@@ -873,13 +897,13 @@ void def_new(char *name) {
   printf("\n");
   #endif
 
-  memset(BUFF, 0, sizeof(Term) * def.nodes_len);
-  memset(rbag, 0, sizeof(Term) * def.rbag_len);
-
-  tm_reset(tm);
+  memset(rnod, 0, rnod_siz);
+  memset(rbag, 0, rbag_siz);
 
   BOOK.defs[BOOK.len] = def;
   BOOK.len++;
+
+  tm_reset(tm);
 }
 
 char *def_name(Loc def_idx) { return BOOK.defs[def_idx].name; }
@@ -913,7 +937,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i+1], offset);
-    rbag_push(tm, neg, pos, false);
+    redex_push(tm, neg, pos, false);
   }
   return root;
 }
@@ -929,35 +953,25 @@ static void boot(Loc def_idx) {
 }
 
 // Atomic Linker
-
 static inline void move(TM *tm, Loc neg_loc, u64 pos);
-static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl);
-
-static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
-  if (term_tag(pos) == VAR) {
-    Term far = swap_lvl(term_loc(pos), neg, lvl);
-    if (term_tag(far) != SUB) {
-      move_lvl(tm, term_loc(pos), far, lvl + 1);
-    }
-  } else {
-    rbag_push(tm, neg, pos, false);
-  }
-}
-
-static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl) {
-  Term neg = swap_lvl(neg_loc, pos, lvl);
-  if (term_tag(neg) != SUB) {
-    // No need to take() since we already swapped
-    link_lvl(tm, neg, pos, lvl + 1);
-  }
-}
 
 static inline void link_terms(TM *tm, Term neg, Term pos) {
-  link_lvl(tm, neg, pos, 0);
+  if (term_tag(pos) == VAR) {
+    Term far = swap(term_loc(pos), neg);
+    if (term_tag(far) != SUB) {
+      move(tm, term_loc(pos), far);
+    }
+  } else {
+    redex_push(tm, neg, pos, false);
+  }
 }
 
 static inline void move(TM *tm, Loc neg_loc, Term pos) {
-  move_lvl(tm, neg_loc, pos, 0);
+  Term neg = swap(neg_loc, pos);
+  if (term_tag(neg) != SUB) {
+    // No need to take() since we already swapped
+    link_terms(tm, neg, pos);
+  }
 }
 
 // Interactions
@@ -971,8 +985,8 @@ static void interact_appref(TM *tm, Term neg, Loc pos_loc) {
     exit(1);
   }
   #endif
-  // Force push to overflow buffer
-  rbag_push(tm, neg, lam, true);
+  // Force push to deferred bag
+  redex_push(tm, neg, lam, true);
 }
 
 static void interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
@@ -1348,8 +1362,6 @@ static void interact_dupref(TM *tm, Loc a_loc, Loc b_loc) {
 }
 
 static void interact_matnul(TM *tm, Loc a_loc, Lab mat_len) {
-  fprintf(stderr, "interact_matnul not supported (yet)\n");
-  exit(1);
   move(tm, port(1, a_loc), term_new(NUL, 0, 0));
   for (u32 i = 0; i < mat_len; i++) {
     link_terms(tm, term_new(ERA, 0, 0), take(port(i + 2, a_loc)));
@@ -1383,23 +1395,19 @@ static void interact_matnum(TM *tm, Loc mat_loc, Lab mat_len, u32 n, Tag n_type)
   }
 }
 
+// NOTE: not tested
 static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {
-  fprintf(stderr, "interact_matsup not supported (yet)\n");
-  exit(1);
-  // TODO: convert to node_alloc( 2 + mat_len * 3)
-
-  /*
-  Loc ma0 = alloc_node(1 + mat_len);
-  Loc ma1 = alloc_node(1 + mat_len);
-  Loc sup = alloc_node(2);
+  Loc ma0 = node_alloc(tm, mat_len + 1);
+  Loc ma1 = node_alloc(tm, mat_len + 1);
+  Loc sup = node_alloc(tm, 2);
 
   set(port(1, sup), term_new(VAR, 0, port(1, ma1)));
   set(port(2, sup), term_new(VAR, 0, port(1, ma0)));
   set(port(1, ma0), term_new(SUB, 0, 0));
   set(port(1, ma1), term_new(SUB, 0, 0));
 
-  for (u64 i = 0; i < mat_len; i++) {
-    Loc dui = alloc_node(2);
+  for (u32 i = 0; i < mat_len; i++) {
+    Loc dui = node_alloc(tm, 2);
     set(port(1, dui), term_new(SUB, 0, 0));
     set(port(2, dui), term_new(SUB, 0, 0));
     set(port(2 + i, ma0), term_new(VAR, 0, port(2, dui)));
@@ -1411,7 +1419,6 @@ static void interact_matsup(TM *tm, Loc mat_loc, Lab mat_len, Loc sup_loc) {
   move(tm, port(1, mat_loc), term_new(SUP, 0, sup));
   link_terms(tm, term_new(MAT, mat_len, ma0), take(port(2, sup_loc)));
   link_terms(tm, term_new(MAT, mat_len, ma1), take(port(1, sup_loc)));
-  */
 }
 
 static void interact_eralam(TM *tm, Loc b_loc) {
@@ -1427,8 +1434,6 @@ static void interact_erasup(TM *tm, Loc b_loc) {
   link_terms(tm, term_new(ERA, 0, 0), tm1);
   link_terms(tm, term_new(ERA, 0, 0), tm2);
 }
-
-static char *tag_to_str(Tag tag);
 
 static bool interact(TM *tm, Term neg, Term pos) {
   Tag neg_tag = term_tag(neg);
@@ -1452,7 +1457,6 @@ static bool interact(TM *tm, Term neg, Term pos) {
       break;
     case REF:
       interact_appref(tm, neg, pos_loc);
-      //link_terms(tm, neg, expand_ref(tm, pos_loc);
       break;
     case SUP:
       interact_appsup(tm, neg_loc, pos_loc);
@@ -1519,11 +1523,9 @@ static bool interact(TM *tm, Term neg, Term pos) {
     case F32:
       interact_dupnum(tm, neg_loc, pos_loc, pos_tag);
       break;
-    // TODO(enricozb): dup-ref optimization
     case REF:
       interact_dupref(tm, neg_loc, pos_loc);
       break;
-    // case REF: link_terms(tm, neg, expand_ref(pos_loc)); break;
     case SUP:
       interact_dupsup(tm, neg_loc, pos_loc);
       break;
@@ -1614,11 +1616,8 @@ static bool sequential_step(TM* tm) {
   return true;
 }
  
-// don't allow idling if our booty bag isn't held
-// because it introduces weirdness that's easier to just ignore for now
- __attribute__((unused))
 static bool can_idle(TM *tm) {
-  return rbag_empty(tm) && bbag_empty(tm) && tm->bhld && oflw_empty(tm);
+  return rbag_empty(tm) && bbag_empty(tm) && !dfer_any(tm);
 }
  
 static bool set_idle(bool was_busy) {
@@ -1635,8 +1634,55 @@ static bool set_busy(bool was_busy) {
   return true;
 }
 
-static u32 get_victim(TM *tm) {
+#if 0
+    for (u64 i = 0; i < PCOR; i++) {
+      u32 vic = (tm->pvic - 1) % TPC;
+      if ((tm->smsk & (1 << vic)) == 0) {
+        tm->pvic = vic;
+        return tm->pvic;
+      }
+      tm->smsk |= (1 << vic);
+    }
+  }
+  tm->smsk &= ~(PCOR-1);
+  tm->pvic = tm->tid % PCOR;
+
+  // Fallback to ECore
+  //tm->evic = ((tm->evic - 1) % (TPC - PCOR)) + PCOR;
+  /*
+  if ((tm->smsk & ((TPC-PCOR-1) << PCOR)) == ((TPC-PCOR-1) << PCOR)) {
+    tm->smsk &= ~((TPC-PCOR-1) << (PCOR));
+  }
+  */
+  for (u64 i = 0; i < (TPC - PCOR); i++) {
+    u32 vic = ((tm->evic - 1) % (TPC - PCOR)) + PCOR;
+    if ((tm->smsk & (1 << vic)) == 0) {
+      tm->evic = vic;
+      return tm->evic;
+    }
+    tm->smsk |= (1 << vic);
+  }
+  tm->smsk &= ~((TPC-PCOR-1) << (PCOR));
+  tm->evic = (tm->tid % (TPC - PCOR)) + PCOR;
+
+  // We've failed all stealing from all threads consecutively - fallback to pvic
+
+  return tm->pvic;
+#endif
+
+static u32 get_victim(TM* tm) {
+#ifdef __APPLE__
+  // PCore bias: if we didn't fail last attempt, or we failed on ECore, try PCore
+  if ((tm->lvic == TPC) || (tm->lvic >= PCOR)) {
+    tm->pvic = (tm->pvic - 1) % PCOR;
+    return tm->pvic;
+  } else {
+    tm->evic = (tm->evic - 1) % ECOR + PCOR;
+    return tm->evic;
+  }
+#else
   return (tm->tid - 1) % TPC;
+#endif
 }
 
 static bool try_steal(TM *tm) {
@@ -1664,15 +1710,28 @@ static bool try_steal(TM *tm) {
   }
   // Our booty bag is either empty, or another thread stole it - try to steal
   // another thread's full bag
-  if (bbag_steal(tm, get_victim(tm))) {
+  u32 vic = get_victim(tm);
+  if (bbag_steal(tm, vic)) {
     tm->sgud += 1;
+    
+    if (tm->lvic < TPC) {
+      if (tm->scnt > tm->smax) {
+        tm->smax = tm->scnt;
+      }
+      tm->stot += tm->scnt;
+      tm->scnt = 0;
+    }
+
+    tm->lvic = TPC;
     return true;
   }
   tm->sbad += 1;
+  tm->lvic = vic;
+
+  tm->scnt += 1;
+
   return false;
 }
-
-#define IDLE 256
 
 static bool timeout(u64 tick) {
   if (tick % IDLE == 0) {
@@ -1684,41 +1743,60 @@ static bool timeout(u64 tick) {
   return false;
 }
 
-static bool lala_and_interact(TM *tm, Pair pair) {
-  if ((tm->sid < TPC) && (tm->spop == 0)) {
-    // The booty bag we stole just became empty
-    if (tm->sid != tm->tid) {
-      // It was another threads bag - toss it
-      bbag_toss(tm);
-    } else {
-      #if 0 || defined(DEBUG)
-      if (bty_debug) {
-        fprintf(stderr, "%u emptied own stolen booty bag\n", tm->tid);
-      }
-      #endif
-    }
-    // No longer stealing
-    tm->sid = TPC;
-  }
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <mach/thread_policy.h>
 
-  return interact(tm, pair_neg(pair), pair_pos(pair));
+void set_affinity(int tid) {
+  thread_affinity_policy_data_t policy;
+  policy.affinity_tag = tid; // 0-3 for P-cores, 4-9 for E-cores
+  thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
+                    (thread_policy_t)&policy, THREAD_AFFINITY_POLICY_COUNT);
 }
+
+void bind_pcore(int tid) {
+    // Set high QoS
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+    set_affinity(tid);
+}
+
+void bind_ecore(int tid) {
+    // Set lower QoS
+    pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
+    set_affinity(tid);
+}
+
+static void bind_core(int tid) {
+  if (tid < PCOR) {
+    bind_pcore(tid);
+  } else {
+    bind_ecore(tid);
+  }
+}
+#endif // __APPLE__
 
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
+
+#ifdef __APPLE__
+  bind_core(thread_id);
+#endif
   TM *tm = tms[thread_id];
 
   // Wait until after injection to turn these on
   tm->buse = true;
-  tm->ouse = true;
+  tm->duse = true;
   //u64 do_nothing = 0;
 
+  __attribute__((unused))
+  u64  fst_steal = 0;
   u64  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
     tick += 1;
 
-    // Try to recover stolen and emptied booty bag
+    // If we know we're not holding our own booty bag, it may have been stolen
+    // and returned - try to recover it
     if (!tm->bhld) {
       bbag_recover(tm);
     }
@@ -1728,35 +1806,34 @@ static void* thread_func(void* arg) {
       busy = set_busy(busy);
       
       Pair pair = take_pair(loc);
-      lala_and_interact(tm, pair);
-
-      #if 1
-      if (tm->bhld && (tm->sid == TPC) && bbag_full(tm)) {
-        // We're holding a full, non-stolen booty bag. Consider dropping it.
-        if (!rbag_empty(tm) || !oflw_empty(tm)) {
-          bbag_drop(tm);
-        }
+      
+      // If we just emptied a stolen bag, return it
+      if (bbag_looted(tm)) {
+        bbag_return(tm);
       }
-      #endif
+
+      interact(tm, pair_neg(pair), pair_pos(pair));
     } else {
       //do_nothing += 1;
       if (busy && can_idle(tm)) {
         busy = set_idle(busy);
       }
-      if (!try_steal(tm) && !busy) {
+      if (!try_steal(tm)) {
         sched_yield();
-        if (timeout(tick))
+        if (!busy && timeout(tick))
           break;
       }
+      #if 1
+      else if (tm->sgud == 1) {
+        fst_steal = tick;
+      }
+      #endif
     }
   }
 
-  //atomic_fetch_add(&net.nods, tm->nput);
-  //atomic_fetch_add(&net.itrs, tm->itrs);
-
   #ifdef SUMMARY
-  fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u oflw %" PRIu64 "\n"); // do_nothing %" PRIu64 "\n",
-          tm->tid, tm->itrs, tm->sgud, tm->sbad, noflw);//, do_nothing);
+  fprintf(stderr, "t%u itrs %" PRIu64 ", steals gud %u bad %u fst %" PRIu64 " max %hu tot %hu\n",
+          tm->tid, tm->itrs, tm->sgud, tm->sbad, fst_steal, tm->smax, tm->stot);
   #endif
   return NULL;
 }
@@ -1788,16 +1865,11 @@ Term normalize(Term term) {
     TM *tm = tms[0];
     while (sequential_step(tm))
       ;
-    net.nods = tm->nput;
-    net.itrs = tm->itrs;
   } else {
     parallel_normalize();
   }
 
   return get(0);
-}
-
-void handle_failure() {
 }
 
 // Debugging
@@ -1839,6 +1911,13 @@ static char *tag_to_str(Tag tag) {
   default:
     return "???";
   }
+}
+
+__attribute__((unused))
+static const char* term_str(char* buf, Term term) {
+  snprintf(buf, 64, "%s lab:%u loc:%u", tag_to_str(term_tag(term)),
+           term_lab(term), term_loc(term));
+  return buf;
 }
 
 static void dump_term(Loc loc) {

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -1,5 +1,4 @@
-// HVM3-Strict Core: single-thread, polarized, LAM/APP & DUP/SUP only
-// parallel support in progress.
+// HVM3-Strict Core: parallel, polarized, LAM/APP & DUP/SUP only
 
 #include <assert.h>
 #include <inttypes.h>
@@ -31,8 +30,6 @@ int thread_create(pthread_t *thread, const pthread_attr_t *attr,
 int thread_join(pthread_t thread, void **retval) {
   return pthread_join(thread, retval);
 }
-
-//const int TPC = get_num_threads(); // don't enable this, change the enum below
 
 // Constants
 #define VAR 0x01
@@ -94,7 +91,7 @@ typedef union {
 } TypeConverter;
 
 // Global heap
-static u64 *BUFF = NULL;  // NOTE: intentionally *not* atomic ptr.
+static u64 *BUFF = NULL;
 
 // Heap configuration options
 enum : u64 {
@@ -107,35 +104,39 @@ enum : u64 {
   HEAP_SIZE = HEAP_1GB * 4,
 
   // Cache line size
-  CLINE_BYTES = 64,
-  CLINE_U64 = CLINE_BYTES / sizeof(u64),
+  CACH_SIZ = 64,
+  CACH_U64 = CACH_SIZ / sizeof(u64),
+  VOID = 0,
 
   // Threads per CPU
   TPC = 10,
 
-  // Various redex bag starting indices within the heap to choose from.
-  // The remaining percentage is used for node storage.
-
-  // Named for the percentage of heap used.
+  // Various redex bag sizes within the heap to choose from. The remaining
+  // percentage is used for node storage. Named for the % of heap used.
+  // TODO: RBAG_10_PCT
   RBAG_25_PCT = (HEAP_SIZE / 4),
   RBAG_50_PCT = (HEAP_SIZE / 2),
   RBAG_75_PCT = (HEAP_SIZE - (HEAP_SIZE / 4)),
   // TODO: something like: RBAG_1024_DEX, for 1024 redex per thread
 
-  ////////////////////////////////////
+  //////////////////////////
   // Choose a RBAG size here
-  ////////////////////////////////////
-  RBAG_SIZE = RBAG_25_PCT
+  //////////////////////////
+  RBAG_SIZE = RBAG_25_PCT,
 };
 
 enum : u32 {
   // Final calculated RBAG index
-  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(u64)) & ~7U, // CLINE_U64 - 1
+  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(u64)) & ~7U, // CACH_U64 - 1
 
   // Calculate RBAG_LEN and NODE_LEN: number of u64 elements *per thread*
-  // TODO: MUST be 16-byte aligned. 64-byte alignment might be preferable.
-  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~7U, // CLINE_U64 - 1
-  NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64))
+  // MUST be 16-byte aligned. 64-byte alignment might be preferable
+  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~7U, // CACH_U64 - 1
+  NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
+
+  // Booty-bag length in u64 elements
+  BBAG_LEN = 96,
+  BBAG_FRQ = 1U << 0
 };
 
 typedef struct Net {
@@ -148,9 +149,9 @@ typedef struct Net {
 typedef struct Def {
   char *name;
   Term *nodes;
-  u64 nodes_len;
+  u64  nodes_len;
   Term *rbag;
-  u64 rbag_len;
+  u64  rbag_len;
 } Def;
 
 typedef struct Book {
@@ -172,63 +173,96 @@ static Book BOOK = {
   .cap = 0,
 };
 
-const Term VOID = 0;
-
 // Local Thread Memory
 typedef struct TM {
   u32 tid;  // thread id
   Loc nput; // next node allocation attempt index
   Loc rput; // next rbag push index
-  Loc sidx; // steal index
-  Loc slst; // last steal index
-  u32 sgud;
-  u32 sbad;
+  Loc bput; // next (owned) bbag push index
+  Loc bpop; // next (stolen) bbag pop index
+  u32 btid; // tid from which bbag was stolen
+  u32 sgud; // successful steals
+  u32 sbad; // failed steals
   u64 itrs; // interaction count
+  bool buse; // use booty bag
 } TM;
 
-static_assert(sizeof(TM) <= CLINE_BYTES, "TM struct getting big");
+static_assert(sizeof(TM) <= CACH_SIZ, "TM struct getting big");
+
+// Booty bag control word values
+enum : u32 {
+  EMPTY = 0,
+  FULL = 1,
+  STOLEN = 2
+};
+
+// Booty bag state
+typedef struct BB {
+  a32 ctrl; // control word
+} BB;
 
 static TM *tms[TPC];
+static BB *bbs[TPC];
+static thread_t threads[TPC];
 
 // Debugging
 static char *tag_to_str(Tag tag);
+static char *bty_ctrl_str(u32 ctrl);
 void dump_term(Loc loc);
 void dump_buff(TM *tm);
 
-// TM operations
+// TM/BS operations
 void tm_reset(TM *tm) {
-  tm->nput = 0;
   tm->rput = 0;
-  tm->sidx = 0;
+  tm->nput = 0;
   tm->itrs = 0;
 }
 
 TM *tm_new(u64 tid) {
-  size_t tm_siz = (sizeof(TM) + CLINE_BYTES - 1) & ~(CLINE_BYTES - 1);
-  TM *tm = aligned_alloc(CLINE_BYTES, tm_siz); // sizeof(TM));
+  size_t tm_siz = (sizeof(TM) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
+  TM *tm = aligned_alloc(CACH_SIZ, tm_siz);
   if (tm == NULL) {
     fprintf(stderr, "TM memory allocation failed\n");
     exit(EXIT_FAILURE);
   }
   tm_reset(tm);
   tm->tid = tid;
-  tm->slst = 0;
+  tm->bput = 0;
+  tm->bpop = 0;
+  tm->btid = 0;
   tm->sgud = 0;
   tm->sbad = 0;
+  tm->buse = false;
   return tm;
 }
 
-void alloc_static_tms() {
+BB *bb_new() {
+  size_t bb_siz = (sizeof(BB) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
+  BB *bb = aligned_alloc(CACH_SIZ, bb_siz);
+  if (bb == NULL) {
+    fprintf(stderr, "BB memory allocation failed\n");
+    exit(EXIT_FAILURE);
+  }
+  bb->ctrl = EMPTY;
+  return bb;
+}
+
+void alloc_static_data() {
   for (u64 t = 0; t < TPC; ++t) {
     tms[t] = tm_new(t);
+    bbs[t] = bb_new();
   }
 }
 
-void free_static_tms() {
+void free_static_data() {
   for (u64 t = 0; t < TPC; ++t) {
     if (tms[t] != NULL) {
       free(tms[t]);
       tms[t] = NULL;
+    }
+    if (bbs[t] != NULL) {
+      free(bbs[t]);
+      bbs[t] = NULL;
     }
   }
 }
@@ -272,9 +306,20 @@ static Term term_offset_loc(Term term, Loc offset) {
   return term_with_loc(term, loc);
 }
 
+static Term term_offset_loc2(Term term, Loc offset) {
+  Tag tag = term_tag(term);
+  if (tag == SUB || tag == NUL || tag == ERA || tag == REF || tag == U32) {
+    return term;
+  } else {
+    Loc loc = term_loc(term) + offset;
+    return (((Term)loc) << 32) | (term & 0xFFFFFFFF);
+  }
+}
+
 //#define DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
+static int bty_debug = 0; // booty bag
 
 static _Thread_local int thread_id = 0;
 
@@ -342,9 +387,17 @@ void set(Loc loc, Term term) {
 }
 
 static Pair take_pair(Loc loc) {
-  Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], 0ULL, __ATOMIC_RELAXED);
-
-#ifdef DEBUG
+#if 0 || defined(ATOMIC)
+  Pair pair = __atomic_exchange_n((Pair*)&BUFF[loc], VOID, __ATOMIC_RELAXED);
+  if (pair == 0) {
+    fprintf(stderr, "%d VOID term taken\n", thread_id);
+    exit(1);
+  }
+#else
+  Pair pair = *(Pair*)&BUFF[loc];
+#endif
+  
+#if 0 || defined(DEBUG)
   if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d take.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
@@ -356,9 +409,13 @@ static Pair take_pair(Loc loc) {
 }
 
 static void set_pair(Loc loc, Pair pair) {
+#ifdef ATOMIC
   __atomic_store_n((Pair*)&BUFF[loc], pair, __ATOMIC_RELAXED);
+#else
+  *((Pair*)&BUFF[loc]) = pair;
+#endif
 
-#ifdef DEBUG
+#if 0 || defined(DEBUG)
   if (mop_debug) {
     char buf[TERMSTR_BUFSIZ];
     fprintf(stderr, "%d set.neg %u %s\n", thread_id, loc, term_str(buf, pair_neg(pair)));
@@ -379,6 +436,10 @@ static Loc node_alloc(TM *tm, u32 num) {
   }
 #endif
 
+  if ((num & 1) == 1) {
+    num += 1;
+  }
+
   if (tm->nput + num >= NODE_LEN) {
     fprintf(stderr, "node space exhausted\n");
     exit(1);
@@ -389,8 +450,77 @@ static Loc node_alloc(TM *tm, u32 num) {
   return loc;
 }
 
+static bool bty_time(TM* tm) {
+  return tm->buse && (tm->bpop == 0) && (tm->itrs % BBAG_FRQ == 0);
+}
+
+static bool bbag_compare_swap(u32 tid, u32 *expected, u32 desired) {
+  u32 orig = *expected;
+
+  bool res = atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, expected,
+                 desired, memory_order_acquire, memory_order_relaxed);
+
+  if (bty_debug) {
+    if (res) {
+      fprintf(stderr, "%d swap of t%u's booty bag from %s to %s succeeded\n",
+              thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desired));
+    } else {
+      if (0) {
+        fprintf(stderr, "%d swap of t%u's booty bag from %s to %s failed, it's %s\n",
+                thread_id, tid, bty_ctrl_str(orig), bty_ctrl_str(desired),
+                bty_ctrl_str(*expected));
+      }
+    }
+  }
+
+  return res;
+}
+
+static void bbag_set(u32 tid, u32 val) {
+  atomic_store_explicit(&bbs[tid]->ctrl, val, memory_order_release);
+
+  if (bty_debug) {
+    fprintf(stderr, "%d set t%u's booty bag to %s\n", thread_id, tid,
+            bty_ctrl_str(val));
+  }
+}
+
+static u32 bbag_get(u32 tid) {
+  u32 got = atomic_load_explicit(&bbs[tid]->ctrl, memory_order_acquire);
+
+  if (0 && bty_debug) {
+    fprintf(stderr, "%d got t%u's booty bag: %s\n", thread_id, tid,
+            bty_ctrl_str(got));
+  }
+
+  return got;
+}
+
+static Loc get_push_offset(TM *tm) {
+  // Consider pushing to booty bag?
+  if (bty_time(tm)) {
+    if (tm->bput >= BBAG_LEN) {
+      // Last we knew, BBAG was full. But maybe it's empty now.
+      if (bbag_get(tm->tid) == EMPTY) {
+        tm->bput = 0;
+
+        if (bty_debug) {
+          fprintf(stderr, "%u own booty bag is newly empty\n", tm->tid);
+        }
+
+        return tm->bput;
+      }        
+    } else {
+      // BBAG isn't full, use it.
+      return tm->bput;
+    }
+  }
+  // Push to RBAG.
+  return BBAG_LEN + tm->rput;
+}
+
 static void rbag_push(TM *tm, Term neg, Term pos) {
-  #if 1 || defined(DEBUG)
+  #ifdef DEBUG
   bool free_global = tm->rput < RBAG_LEN - 1;
   if (!free_global) {
     fprintf(stderr, "rbag space exhausted\n");
@@ -398,22 +528,60 @@ static void rbag_push(TM *tm, Term neg, Term pos) {
   }
   #endif
 
-  Loc loc = RBAG + tm->tid * RBAG_LEN + tm->rput;
+  Loc off = get_push_offset(tm);
+  bool bty = off < BBAG_LEN;
+  Loc loc = RBAG + tm->tid * RBAG_LEN + off;
 
 #ifdef DEBUG
-  if (0 && mop_debug) {
-    fprintf(stderr, "%u calling set_pair @ %u, rput %u\n", tm->tid, loc, tm->rput);
+  if (mop_debug) {
+    fprintf(stderr, "%u calling set_pair @ %u, rput %u\n", tm->tid, loc,
+            tm->rput);
   }
 #endif
 
   set_pair(loc, pair_new(neg, pos));
-  tm->rput += 2;
+
+  if (bty) {
+    if (bty_debug) {
+      fprintf(stderr, "%u pushed to booty bag @ %u\n", tm->tid, tm->bput);
+      char buf[TERMSTR_BUFSIZ];
+      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, neg));
+      fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pos));
+    }
+
+    tm->bput += 2;
+    if (tm->bput == BBAG_LEN) {
+      bbag_set(tm->tid, FULL);
+
+      if (0 && bty_debug) {
+        fprintf(stderr, "%u booty bag full\n", tm->tid);
+      }
+    }
+  } else {
+    tm->rput += 2;
+  }
 }
 
 static Pair rbag_pop(TM* tm) {
-  if (tm->rput > 0) {
+  if (tm->bpop > 0) {
+    // If we have a stolen booty bag, use it
+    tm->bpop -= 2;
+
+    // If stealing from own booty bag, adjust push index as well
+    if (tm->btid == tm->tid) {
+      tm->bput -= 2;
+    }
+
+    if (bty_debug) {
+      fprintf(stderr, "%u popping from t%u's booty bag @ %u\n", tm->tid,
+              tm->btid, tm->bpop);
+    }
+
+    return RBAG + tm->btid * RBAG_LEN + tm->bpop;
+  } else if (tm->rput > 0) {
+    // Else if RBAG isn't empty, use it
     tm->rput -= 2;
-    return RBAG + tm->tid * RBAG_LEN + tm->rput;
+    return RBAG + tm->tid * RBAG_LEN + BBAG_LEN + tm->rput;
   } else {
     return 0;
   }
@@ -422,7 +590,7 @@ static Pair rbag_pop(TM* tm) {
 // FFI functions
 void hvm_init() {
   if (BUFF == NULL) {
-    BUFF = aligned_alloc(CLINE_BYTES, HEAP_SIZE);
+    BUFF = aligned_alloc(CACH_SIZ, HEAP_SIZE);
     if (BUFF == NULL) {
       fprintf(stderr, "Heap memory allocation failed\n");
       exit(EXIT_FAILURE);
@@ -430,7 +598,7 @@ void hvm_init() {
   }
   memset(BUFF, 0, HEAP_SIZE);
 
-  alloc_static_tms();
+  alloc_static_data();
 
   #if 0 
   fprintf(stderr, "HEAP_SIZE = %" PRIu64 "\n", HEAP_SIZE);
@@ -446,16 +614,21 @@ void hvm_free() {
     free(BUFF);
     BUFF = NULL;
   }
-  free_static_tms();
+  free_static_data();
 }
 
 Loc ffi_alloc_node(u64 arity) {
-  // Only called by Inject.hs. This is a special case of node allocation
-  // where we know nodes will be contiguous.
   TM *tm = tms[0];
+#if 1
   Loc loc = tm->nput;
+  //if ((arity & 1) == 1) {
+  //  arity += 1;
+  //}
   tm->nput += arity;
   return loc;
+#else
+  return node_alloc(tm, arity);
+#endif
 }
 
 void ffi_rbag_push(Term neg, Term pos) {
@@ -497,14 +670,14 @@ void def_new(char *name) {
 
   Loc rbag_end = tm->rput;
   Loc rnod_end = tm->nput;
-  size_t rbag_siz = ((sizeof(Term) * rbag_end) + CLINE_BYTES - 1) & ~(CLINE_BYTES - 1);
-  size_t rnod_siz = ((sizeof(Term) * rnod_end) + CLINE_BYTES - 1) & ~(CLINE_BYTES - 1);
+  size_t rbag_siz = ((sizeof(Term) * rbag_end) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
+  size_t rnod_siz = ((sizeof(Term) * rnod_end) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
 
   Def def = {
       .name = name,
-      .nodes = aligned_alloc(CLINE_BYTES, rnod_siz),
+      .nodes = aligned_alloc(CACH_SIZ, rnod_siz),
       .nodes_len = rnod_end,
-      .rbag = aligned_alloc(CLINE_BYTES, rbag_siz),
+      .rbag = aligned_alloc(CACH_SIZ, rbag_siz),
       .rbag_len = rbag_end,
   };
 
@@ -512,15 +685,17 @@ void def_new(char *name) {
     fprintf(stderr, "DEF memory allocation failed\n");
   }
 
+  u64 *rbag = BUFF + RBAG + BBAG_LEN;
+
   memcpy(def.nodes, BUFF, sizeof(Term) * def.nodes_len);
-  memcpy(def.rbag, BUFF + RBAG, sizeof(Term) * def.rbag_len);
+  memcpy(def.rbag, rbag, sizeof(Term) * def.rbag_len);
 
   // printf("NEW DEF '%s':\n", def.name);
   // dump_buff();
   // printf("\n");
 
   memset(BUFF, 0, sizeof(Term) * def.nodes_len);
-  memset(BUFF + RBAG, 0, sizeof(Term) * def.rbag_len);
+  memset(rbag, 0, sizeof(Term) * def.rbag_len);
 
   tm_reset(tm);
 
@@ -557,10 +732,26 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   Term root = term_offset_loc(nodes[0], offset);
 
   // No redexes reference these nodes yet; therefore, safe to add un-atomically.
-  for (u32 i = 1; i < nodes_len; i++) {
-    Loc loc = offset + i;
-    Term term = term_offset_loc(nodes[i], offset);
+  // TODO: ensure nodes always 16-byte aligned to enable 128-bit stores
+  #define STORE_128
+  #ifndef STORE_128
+  for (u32 n = 1; n < nodes_len; n++) {
+  #else
+  u32 n = 1;
+  for (; n + 1 < nodes_len; n += 2) {
+  #endif
+    
+    Loc loc = offset + n;
+
+    #ifndef STORE_128
+    Term term = term_offset_loc(nodes[n], offset);
     BUFF[loc] = term;
+    #else
+    Pair pair = *(Pair*)&nodes[n];
+    pair = pair_new(term_offset_loc(pair_neg(pair), offset),
+                    term_offset_loc(pair_pos(pair), offset));
+    *(Pair*)&BUFF[loc] = pair;
+    #endif
 
 #ifdef DEBUG
     if (mop_debug) {
@@ -569,6 +760,12 @@ static Term expand_ref(TM *tm, Loc def_idx) {
     }
 #endif
   }
+  #ifdef STORE_128
+  if (n < nodes_len) {
+    Term term = term_offset_loc(nodes[n], offset);
+    BUFF[offset + n] = term;
+  }
+  #endif
 
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
@@ -584,7 +781,7 @@ static void boot(Loc def_idx) {
     fprintf(stderr, "booting on non-empty state\n");
     exit(1);
   }
-  tm->nput = 1; // node_alloc(tm, 1), effectively
+  node_alloc(tm, 1);
   set(0, expand_ref(tm, def_idx));
 }
 
@@ -1235,7 +1432,7 @@ static bool set_idle(bool was_busy) {
   if (was_busy) {
     u32 idle = atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
     if (thd_debug) {
-      fprintf(stderr, "%u set idle, was idle= %u\n", thread_id, idle);
+      fprintf(stderr, "%u set idle, was idle = %u\n", thread_id, idle);
     }
 
   }
@@ -1252,67 +1449,65 @@ static bool set_busy(bool was_busy) {
   return true;
 }
 
-static u32 choose_victim(TM *tm) {
+static u32 get_victim(TM *tm) {
   return (tm->tid - 1) % TPC;
 }
 
 static bool try_steal(TM *tm) {
-  u32 sid = choose_victim(tm);
-  Loc loc = 0;
+  if (!tm->buse) return false;
 
- retry:
-  loc = RBAG + sid * RBAG_LEN + tm->sidx;
+  // Check if our own booty bag has anything in it.
+  if (tm->bput > 0) {
+    // If it's not full, we can steal without atomics.
+    if (tm->bput < BBAG_LEN) {
+      tm->bpop = tm->bput;
+      tm->btid = tm->tid;
 
-  if (thd_debug) {
-    fprintf(stderr, "%u try stealing from %u @ %u : %u\n", tm->tid, sid,
-        tm->sidx, loc);
+      if (bty_debug) {
+        fprintf(stderr, "%u stealing own non-full booty bag, len = %u\n",
+                tm->tid, tm->bpop);
+      }
+
+      return true;
+    } else {
+      u32 state = FULL;
+      if (bbag_compare_swap(tm->tid, &state, EMPTY)) {
+        tm->bpop = tm->bput; // BBAG_LEN, always
+        tm->btid = tm->tid;
+
+        if (bty_debug) {
+          fprintf(stderr, "%u stealing own full booty bag, len = %u\n",
+                  tm->tid, tm->bpop);
+        }
+
+        return true;
+      } else {
+        if (bty_debug) {
+          fprintf(stderr, "%u failed to steal own full booty bag, state = %s\n",
+                  tm->tid, bty_ctrl_str(state));
+        }
+      }
+    }
   }
 
-  Pair got = take_pair(loc);
+  // Nothing in our booty bag, or another thread stole it.
+  // Try to steal from another thread.
+  u32 vic = get_victim(tm);
+  u32 full = FULL;
+  if (bbag_compare_swap(vic, &full, STOLEN)) {
+    tm->bpop = BBAG_LEN;
+    tm->btid = vic;
+    tm->sgud += 1;
 
-  if (got != 0) {
-    if (thd_debug) { fprintf(stderr, "%u success, pushing...\n", tm->tid); }
-
-    rbag_push(tm, pair_neg(got), pair_pos(got));
-
-    if (thd_debug) { fprintf(stderr, "%u steal done\n", tm->tid); }
-
-    tm->slst = tm->sidx;
-    tm->sidx += 2;
-    tm->sgud++;
+    if (0 && bty_debug) {
+      fprintf(stderr, "%u stealing t%u's booty bag, \n", tm->tid, tm->btid);
+    }
 
     return true;
-  } else {
-    if (thd_debug) { fprintf(stderr, "%u steal failed\n", tm->tid); }
-
-    tm->sbad++;
-
-    // The logic here, is that since we know the index of our last successful
-    // steal, we should always trying stealing up to at least that index (-2).
-    //
-    // Because that index is where the owning thread *may* have pushed it's
-    // next redex.
-    //
-    // That, and no yields() while we attempt up to that index. Only yield
-    // when we reset to zero.
-    //
-    // It's entirely possible i've introduced a race condition with this logic;
-    // it should be considered experimental and not thoroughly tested.
-    //
-    // If you ever randomly see a result like "v12345", it's may be due to this.
-    //
-    #define STABLE // to make it more stable
-    //
-    #ifndef STABLE
-    if (tm->sidx + 2 < tm->slst) {
-      tm->sidx += 2;
-      goto retry;
-    } else
-    #endif
-      tm->sidx = 0;
-
-    return false;
   }
+
+  tm->sbad += 1;
+  return false;
 }
 
 static bool check_timeout(u32 tick) {
@@ -1332,17 +1527,50 @@ static void* thread_func(void* arg) {
   thread_id = (u64)arg;
   TM *tm = tms[thread_id];
 
+  // Use booty bag. Wait to turn this on after injection.
+  // TODO: this could be a global net flag i think.
+  tm->buse = true;
+
   //sync_threads();
 
   u32  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
     tick += 1;
+    Loc prev_bpop = tm->bpop; // haxor
     Loc loc = rbag_pop(tm);
     if (loc) {
       busy = set_busy(busy);
 
       Pair pair = take_pair(loc);
+
+      //bbag_maybe_empty(tm, prev_bpop);
+
+      if (prev_bpop > 0) {
+        if (bty_debug) {
+          char buf[TERMSTR_BUFSIZ];
+          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_neg(pair)));
+          fprintf(stderr, "%u   %s\n", tm->tid, term_str(buf, pair_pos(pair)));
+        }
+
+        if (tm->bpop == 0) {
+          if (tm->btid != tm->tid) {
+            // Mark stolen booty bag empty.
+            bbag_set(tm->btid, EMPTY);
+            
+            if (0 && bty_debug) {
+              fprintf(stderr, "%u finished popping from t%u's booty bag\n",
+                      tm->tid, tm->btid);
+            }
+          } else {
+            if (bty_debug) {
+              fprintf(stderr, "%u finished popping from own booty bag\n",
+                      tm->tid);
+            }
+          }
+        }
+      }
+
       if (pair != 0) {
         interact(tm, pair_neg(pair), pair_pos(pair));
       }
@@ -1352,6 +1580,7 @@ static void* thread_func(void* arg) {
       if (try_steal(tm)) continue;
 
       sched_yield();
+      //usleep(1);
 
       if (check_timeout(tick)) break;
     }
@@ -1360,28 +1589,26 @@ static void* thread_func(void* arg) {
   atomic_fetch_add(&net.nods, tm->nput);
   atomic_fetch_add(&net.itrs, tm->itrs);
 
-  if (0) {
-    fprintf(stderr, "t%u: %" PRIu64 " itrs, steals: %u good %u bad\n",
-            tm->tid, tm->itrs, tm->sgud, tm->sbad);
+  if (1) {
+    fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, bpop: %u, steals: %u good %u bad\n",
+            tm->tid, tm->itrs, tm->rput, tm->bput, tm->bpop, tm->sgud, tm->sbad);
   }
 
-  if (thd_debug) {
-    fprintf(stderr, "%u before sync...\n", tm->tid);
-  }
+  //if (thd_debug) {
+  //  fprintf(stderr, "%u before sync...\n", tm->tid);
+  //}
 
   // sync_threads();
 
-  if (thd_debug) {
-    fprintf(stderr, "%u after sync done\n", tm->tid);
-  }
+  //if (thd_debug) {
+  //  fprintf(stderr, "%u after sync done\n", tm->tid);
+  //}
 
   return NULL;
 }
 
 static void parallel_normalize() {
-  thread_t threads[TPC];
-
-  // Initializes the global idle counter
+  // Initialize the global idle counter
   atomic_store_explicit(&net.idle, TPC - 1, memory_order_relaxed);
 
   for (u64 i = 0; i < TPC; i++) {
@@ -1452,6 +1679,15 @@ static char *tag_to_str(Tag tag) {
 
   default:
     return "???";
+  }
+}
+
+static char *bty_ctrl_str(u32 ctrl) {
+  switch (ctrl) {
+  case EMPTY:  return "EMPTY";
+  case FULL:   return "FULL";
+  case STOLEN: return "STOLEN";
+  default:     return "???";
   }
 }
 

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdalign.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -16,7 +17,7 @@
 #include <unistd.h>
 
 //#define DEBUG
-#define MEMLOG
+//#define MEMLOG
 
 #define DEBUG_LOG(fmt, ...) fprintf(stderr, "[DEBUG] " fmt "\n", ##__VA_ARGS__)
 
@@ -97,21 +98,22 @@ __asm__(
 #define OP_RSH 0x0F
 
 // Types
-typedef int32_t i32;
-typedef uint32_t u32;
+typedef uint8_t      u8;
+typedef int32_t      i32;
+typedef uint32_t     u32;
 typedef _Atomic(u32) a32;
-typedef float f32;
-typedef int64_t i64;
-typedef uint64_t u64;
+typedef float        f32;
+typedef int64_t      i64;
+typedef uint64_t     u64;
 typedef _Atomic(u64) a64;
-// NOTE alignment is gcc/clang specific
+// NOTE typedef alignment is gcc/clang specific
 typedef unsigned __int128 u128 __attribute__((aligned(16)));
 
-typedef uint8_t Tag; //  8 bits
-typedef u32 Lab;     // 24 bits
-typedef u32 Loc;     // 32 bits
-typedef u64 Term;    // Loc | Lab | Tag
-typedef u128 Pair;   // Term | Term
+typedef u8   Tag;  //  8 bits
+typedef u32  Lab;  // 24 bits
+typedef u32  Loc;  // 32 bits
+typedef u64  Term; // Loc | Lab | Tag
+typedef u128 Pair; // Term | Term
 
 // Using union for type punning (safer in C)
 typedef union {
@@ -136,38 +138,51 @@ enum : u64 {
   // Cache line size
   CACH_SIZ = 64,
   CACH_U64 = CACH_SIZ / sizeof(u64),
-  VOID = 0,
+  ZERO = 0,
 
   // Threads per CPU
-  TPC = 10,
+  TPC = 2,
+
+  // Number of terms *per thread* for each overflow bag. There are two of them,
+  // and they (currently) steal space from each thread's RBAG space.
+  // NB: These numbers are a bit aggresive. Overflow of overflow could happen.
+  OFLW_LEN = 2048,
+  OFLW_SYNC = OFLW_LEN / 2,
 
   // Various redex bag sizes within the heap to choose from. The remaining
   // percentage is used for node storage.
-  RBAG_4096 = 4096 * TPC * sizeof(Term),
+  //RBAG_4096 = 4096 * TPC * sizeof(Term),
+  RBAG_8192 = 8192 * TPC * sizeof(Term),
 
   //////////////////////////
   // Choose a RBAG size here
   //////////////////////////
-  RBAG_SIZE = RBAG_4096,
+  RBAG_SIZE = RBAG_8192,
 };
 
 enum : u32 {
   // Final calculated RBAG index
-  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(u64)) & ~7U, // CACH_U64 - 1
+  RBAG = ((HEAP_SIZE - RBAG_SIZE) / sizeof(Term)) & ~7U, // CACH_U64 - 1
 
   // Calculate RBAG_LEN and NODE_LEN: number of u64 elements *per thread*
   // RBAG_LEN MUST be 16-byte aligned. 64-byte alignment might be preferable
-  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(u64))) & ~7U, // CACH_U64 - 1
-  NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
+  RBAG_LEN = (RBAG_SIZE / (TPC * sizeof(Term))) & ~7U, // CACH_U64 - 1
+  NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(Term)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 8
+  BBAG_LEN = 96,
+
+  // Offset in RBAG of overflow bags
+  OFLW_INI = RBAG_LEN - (OFLW_LEN * 2),
+
+  // Max terms allowed in RBAG, taking into account booty bag and overflow
+  RPUT_MAX = OFLW_INI - BBAG_LEN
 };
 
 typedef struct Net {
   a64 nods;
   a64 itrs;
-  a32 idle;
+  a32 alignas(64) idle;  // TODO Probably should just make it a64
 } Net;
 
 // Global book
@@ -205,22 +220,29 @@ typedef struct TM {
   u32 tid;   // thread id
   Loc nput;  // next node allocation attempt index
   Loc rput;  // next rbag push index
-  Loc bput;  // (owned) bbag push index
   u32 sid;   // tid from which bbag was stolen
+  Loc bput;  // owned bbag push index
   Loc spop;  // stolen bbag pop index + 2
 
   u32 sgud;  // successful steal count
   u32 sbad;  // failed steal count
 
-  // memlog
+  Loc oput[2]; // next oflw bag push indices
+  
+#ifdef MEMLOG
   u32 mput;
   u32 itid;
-  uint8_t i1_tag;
-  uint8_t i2_tag;
+  u8 i1_tag;
+  u8 i2_tag;
   bool mwrp; // memlog wrapped
+#endif
 
-  bool buse; // use booty bag
+  bool buse; // can use booty bag
   bool bful; // ctrl word marked full
+  u8   opid; // oput idx we are pushing into
+  bool ouse; // can use overflow
+  bool osyn; // overflow is sync'd
+  //bool otak; // can take from overflow
 
   u64 itrs;  // interaction count
 } TM;
@@ -235,11 +257,11 @@ enum : u32 {
 };
 
 typedef struct BB {
-  a32 ctrl; // control word
+  a32 alignas(64) ctrl; // control word TODO: just make it a64
 } BB;
 
 static TM *tms[TPC];
-static BB *bbs[TPC];
+static BB bbs[TPC];
 static thread_t threads[TPC];
 static uint8_t unprocessed_itrs[255] = { 0 };
 
@@ -277,12 +299,13 @@ enum : u32 {
 #define MLOG_LVL(mop, loc, lvl, t1, t2)
 #endif
 
-static u32 u64_hi(u64 e) {
-  return e >> 32;
+static u32 u64_hi(u64 u) {
+  return (u >> 32) & 0xFFFFFFFF;
 }
 
-static u32 u64_lo(u64 e) {
-  return e & 0xFFFFFFFF;
+__attribute__((unused))
+static u32 u64_lo(u64 u) {
+  return u & 0xFFFFFFFF;
 }
 
 // Memory operations
@@ -290,6 +313,7 @@ static u32 u64_lo(u64 e) {
 #define MOP_LOAD 0x02
 #define MOP_STOR 0x03
 
+__attribute__((unused))
 static const char* mop_str(u32 mop) {
   switch (mop) {
   case MOP_EXCH: return "EXCH";
@@ -436,11 +460,7 @@ static void mlog_dump(const char* fn) {
         off = 0;
       }
       mlog_dump_range(fp, ini, off, end, &nlog);
-      //fprintf(stderr, "%u dumped %u wrapped entries, off %u end %u\n",
-      //tid, wrapped, off, end);
     }
-    //fprintf(stderr, "%u dumped %u %s\n", tid, nlog,
-    //tm->mwrp ? "wrapped" : "no wrap");
   }
   fclose(fp);
 }
@@ -502,14 +522,16 @@ void mlog_exit() {
   exit(1);
 }
 
-// TM/BS operations
+// TM/BB operations
 void tm_reset(TM *tm) {
   tm->rput = 0;
   tm->nput = 0;
   tm->itrs = 0;
 
+#ifdef MEMLOG
   tm->mput = 0;
   tm->mwrp = false;
+#endif
 }
 
 TM *tm_new(u64 tid) {
@@ -527,13 +549,20 @@ TM *tm_new(u64 tid) {
   tm->sid = TPC;
   tm->sgud = 0;
   tm->sbad = 0;
-  tm->buse = false;
+  tm->oput[0] = 0;
+  tm->oput[1] = 0;
+  tm->opid = 0;
   tm->bful = false;
+  tm->buse = false;
+  tm->ouse = false;
+  //tm->otak = false;
+  tm->osyn = false;
 
   return tm;
 }
 
-BB *bb_new() {
+#if 0
+static BB *bb_new() {
   size_t bb_siz = (sizeof(BB) + CACH_SIZ - 1) & ~(CACH_SIZ - 1);
   BB *bb = aligned_alloc(CACH_SIZ, bb_siz);
   if (bb == NULL) {
@@ -543,24 +572,27 @@ BB *bb_new() {
   bb->ctrl = EMPTY;
   return bb;
 }
+#endif
 
-void alloc_static_data() {
+static void alloc_static_data() {
   for (u64 t = 0; t < TPC; ++t) {
     tms[t] = tm_new(t);
-    bbs[t] = bb_new();
+    //bbs[t] = bb_new();
   }
 }
 
-void free_static_data() {
+static void free_static_data() {
   for (u64 t = 0; t < TPC; ++t) {
     if (tms[t] != NULL) {
       free(tms[t]);
       tms[t] = NULL;
     }
+    #if 0
     if (bbs[t] != NULL) {
       free(bbs[t]);
       bbs[t] = NULL;
     }
+    #endif
   }
 }
 
@@ -584,7 +616,7 @@ Term term_new(Tag tag, Lab lab, Loc loc) {
 
 Lab term_lab(Term term) { return (term >> 8) & 0xFFFFFF; }
 
-Loc term_loc(Term term) { return (term >> 32) & 0xFFFFFFFF; }
+Loc term_loc(Term term) { return u64_hi(term); }
 
 static Term term_with_loc(Term term, Loc loc) {
   return (((Term)loc) << 32) | (term & 0xFFFFFFFF);
@@ -604,8 +636,9 @@ static Term term_offset_loc(Term term, Loc offset) {
 #ifdef DEBUG
 static int mop_debug = 0; // memory operations
 static int thd_debug = 0; // threading
-static int bty_debug = 1; // booty bag
+static int bty_debug = 0; // booty bag
 #endif
+static int oflw_debug = 0; // overflow
 
 __attribute__((unused))
 static const char* term_str(char* buf, Term term) {
@@ -618,7 +651,7 @@ static const char* term_str(char* buf, Term term) {
 Term swap_lvl(Loc loc, Term term, u32 lvl) {
   Term got = atomic_exchange_explicit((a64*)&BUFF[loc], term, memory_order_relaxed);
   MLOG_LVL(MOP_EXCH, loc, lvl, got, term);
-#if 1
+#ifdef MEMLOG
   if (got == 0) {
     fprintf(stderr, "%d swap got NULL @ %u\n", thread_id, loc);
     mlog_exit();
@@ -632,12 +665,14 @@ Term swap(Loc loc, Term term) {
 }
 
 Term take(Loc loc) {
-  Term term = atomic_exchange_explicit((a64*)&BUFF[loc], VOID, memory_order_relaxed);
+  Term term = atomic_exchange_explicit((a64*)&BUFF[loc], ZERO, memory_order_relaxed);
   MLOG(MOP_EXCH, loc, term, 0);
+#ifdef MEMLOG
   if (term == 0) {
     fprintf(stderr, "%d take got NULL @ %u\n", thread_id, loc);
     mlog_exit();
   }
+#endif
   return term;
 }
 
@@ -655,7 +690,7 @@ void set(Loc loc, Term term) {
 static Pair take_pair(Loc loc, bool bty) {
   Pair pair = *(Pair*)&BUFF[loc];
   
-#define VOID_TEST
+  //#define VOID_TEST
 
   // Debugging
 #if defined(MEMLOG) || defined(VOID_TEST)
@@ -672,7 +707,7 @@ static Pair take_pair(Loc loc, bool bty) {
   MLOG_PAIR(MOP_LOAD, loc, pair);
 
 #ifdef VOID_TEST
-  //*(Pair*)&BUFF[loc] = (Pair)VOID;
+  //*(Pair*)&BUFF[loc] = (Pair)ZERO;
   if ((neg == 0) || (pos == 0)) {
     fprintf(stderr, "%d take_pair: void term taken\n", thread_id);
     mlog_exit();
@@ -705,6 +740,15 @@ static Loc rnod_ini(u32 tid) {
   return tid * NODE_LEN;
 }
 
+static Loc oflw_offset(u32 oidx) {
+  return OFLW_INI + OFLW_LEN * oidx;
+}
+
+static Loc oflw_ini(u32 tid, u32 oidx) {
+  // maybe some tricky trick when we know odix can only be zero or one
+  return bbag_ini(tid) + oflw_offset(oidx);
+}
+
 // Allocator
 // ---------
 
@@ -733,60 +777,92 @@ static Loc node_alloc(TM *tm, u32 cnt) {
 
 static bool bbag_compare_swap(u32 tid, u32 expect, u32 desire,
                               memory_order success_order) {
-  return atomic_compare_exchange_strong_explicit(&bbs[tid]->ctrl, &expect,
+  return atomic_compare_exchange_strong_explicit(&bbs[tid].ctrl, &expect,
       desire, success_order, memory_order_relaxed);
 }
 
 static void bbag_set(u32 tid, u32 val, memory_order order) {
-  atomic_store_explicit(&bbs[tid]->ctrl, val, order);
+  atomic_store_explicit(&bbs[tid].ctrl, val, order);
 }
 
 static u32 bbag_get(u32 tid) {
-  return atomic_load_explicit(&bbs[tid]->ctrl, memory_order_relaxed);
+  return atomic_load_explicit(&bbs[tid].ctrl, memory_order_relaxed);
 }
 
-static Loc get_push_offset(TM *tm) {
+static Loc get_push_offset(TM *tm, bool force_oflw) {
+  if (force_oflw && tm->ouse) {
+    #if 0 || defined(DEBUG)
+    if (oflw_debug) {
+      fprintf(stderr, "%u pushing to overflow %u @ %u\n", tm->tid,
+            0u+tm->opid, tm->oput[tm->opid]);
+    }
+    #endif
+
+    return oflw_offset(tm->opid) + tm->oput[tm->opid];
+  }
+
   // Only push to booty bag if we aren't stealing
   if (tm->buse && !tm->bful && (tm->bput < BBAG_LEN) && (tm->sid == TPC)) {
-
-#ifdef DEBUG
-  fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
-#endif
+    #ifdef DEBUG
+    fprintf(stderr, "%u pushing to booty bag @ %u\n", tm->tid, tm->bput);
+    #endif
 
     return tm->bput;
   }
 
-#ifdef DEBUG
+  #ifdef DEBUG
   fprintf(stderr, "%u pushing to RBAG @ %u\n", tm->tid, tm->rput);
-#endif
-
+  #endif
   // Push to RBAG
   return BBAG_LEN + tm->rput;
 }
 
-static void rbag_push(TM *tm, Term neg, Term pos) {
-  Loc off = get_push_offset(tm);
-  bool to_bty = off < BBAG_LEN;
+static void rbag_push(TM *tm, Term neg, Term pos, bool force_oflw) {
+  Loc off = get_push_offset(tm, force_oflw);
   Loc loc = bbag_ini(tm->tid) + off;
 
   set_pair(loc, pair_new(neg, pos));
 
-  if (to_bty) {
+  // TODO: adjust_put_idx(tm, off);
+  if (off < BBAG_LEN) {
+    // pushed to booty bag
     tm->bput += 2;
-  } else {
-    //#ifdef DEBUG
-    bool free_global = tm->rput < RBAG_LEN - BBAG_LEN - 1;
-    if (!free_global) {
-      fprintf(stderr, "rbag space exhausted\n");
+  } else if (off >= OFLW_INI) {
+    // pushed to overflow
+    if (tm->oput[tm->opid] >= OFLW_LEN-1) {
+      fprintf(stderr, "%u overflow %u space exhausted\n", tm->tid, tm->opid);
       exit(1);
     }
-    //#endif
-
+    tm->oput[tm->opid] += 2;
+  } else {
+    // pushed to RBAG
+    if (tm->rput >= RPUT_MAX-1) {
+      fprintf(stderr, "%u rbag space exhausted\n", tm->tid);
+      exit(1);
+    }
     tm->rput += 2;
   }
 }
 
-static Pair rbag_pop(TM* tm) {
+static Loc redex_pop_loc(TM* tm) {
+  // Must check overflow bag first when sync'd
+  if (tm->ouse && tm->osyn) {
+    u32 oidx = 1u - tm->opid;
+    u32 oput = tm->oput[oidx];
+    if (oput > 0) {
+      oput -= 2;
+      tm->oput[oidx] = oput;
+
+      #if 0 || defined(DEBUG)
+      if (oflw_debug) {
+        fprintf(stderr, "%u popping from overflow %u @ %u\n", tm->tid,
+                oidx, oput);
+      }
+      #endif
+
+      return oflw_ini(tm->tid, oidx) + oput;
+    }
+  } 
   if (tm->spop > 0) {
     // Pop from stolen, non-empty booty bag
     tm->spop -= 2;
@@ -854,7 +930,7 @@ Loc ffi_alloc_node(u64 arity) {
 }
 
 void ffi_rbag_push(Term neg, Term pos) {
-  rbag_push(tms[0], neg, pos);
+  rbag_push(tms[0], neg, pos, false);
 }
 
 u64 inc_itr() {
@@ -875,67 +951,6 @@ Loc ffi_rnod_end() {
   return atomic_load(&net.nods);
 }
 
-int cmp_u32(const void *a, const void *b) {
-  u32 aa = *(const u32*)a;
-  u32 bb = *(const u32*)b;
-  return (aa > bb) - (bb < aa);
-}
-
-u32 upr_bnd(Loc *locs, u32 cnt, Loc tgt) {
-  u32 lft = 0;
-  u32 rgt = cnt;
-  while (lft < rgt) {
-    u32 mid = lft + (rgt - lft) / 2;
-    if (locs[mid] > tgt) {
-      rgt = mid;
-    } else {
-      lft = mid + 1;
-    }
-  }
-  return lft;
-}
-
-__attribute__((unused))
-static u32 dup_bod(Term *src, Term *dst, u32 nsrc) {
-  Term lam = src[0];
-  if (term_tag(lam) != LAM) return 0;
-
-  Term arg = src[1];
-  // Don't know how to deal with this.
-  if (term_tag(arg) == MAT) return 0;
-
-  Term bod = src[2];
-  if (term_tag(bod) != VAR) return 0;
-  
-  Loc bod_loc = term_loc(bod);
-  // Another weird case I can't deal with.
-  if (bod_loc < 2) return 0;
-
-  Loc *locs = (Loc *)(dst + nsrc * 2);
-  *locs = bod_loc;
-  
-  u32 nloc = 1;
-
-  // Copy all terms, updating their locs, and duplicating terms at
-  // locations in locs array
-  for (u32 i = 0, loc_idx = 0; i < nsrc; i++) {
-    Term trm = src[i];
-    if (term_has_loc(trm)) {
-      Loc loc = term_loc(trm);
-      if (loc > *locs) {
-        loc += 1;
-      }
-      trm = term_with_loc(trm, loc);
-    }
-    dst[i + loc_idx] = trm;
-    if ((loc_idx < nloc) && (i == locs[loc_idx])) {
-      loc_idx += 1;
-      dst[i + loc_idx] = trm;
-    }
-  }
-  return nloc;
-}
-
 // Moves the global buffer and redex bag into a new def and resets
 // the global buffer and redex bag.
 void def_new(char *name) {
@@ -953,18 +968,6 @@ void def_new(char *name) {
   Loc rnod_cnt = tm->nput;
   Loc rbag_cnt = tm->rput;
 
-  u32 node_ini = align(CACH_SIZ, rnod_cnt);
-  // assert((mnod_ini + rnod_cnt * 3) < RBAG);
-  Term *nodes = &BUFF[node_ini];
-
-  u32 ndup = 0; //dup_bod(BUFF, nodes, rnod_cnt);
-
-  if (ndup == 0) {
-    nodes = BUFF;
-  } else {
-    rnod_cnt += ndup;
-  }
-
   u64 rbag_siz = align(CACH_SIZ, sizeof(Term) * rbag_cnt);
   u64 rnod_siz = align(CACH_SIZ, sizeof(Term) * rnod_cnt);
 
@@ -981,22 +984,16 @@ void def_new(char *name) {
     exit(1);
   }
 
+  Term *nodes = BUFF;
   Term *rbag = &BUFF[rbag_ini(0)];
 
   memcpy(def.nodes, nodes, sizeof(Term) * def.nodes_len);
   memcpy(def.rbag, rbag, sizeof(Term) * def.rbag_len);
 
 #if 0
-  if (ndup) {
-    if (ndup) {
-      memcpy(BUFF, nodes, sizeof(Term) * def.nodes_len);
-      tm->nput = def.nodes_len;
-    }
-
-    printf("NEW DEF '%s':\n", def.name);
-    dump_buff();
-    printf("\n");
-  }
+  printf("NEW DEF '%s':\n", def.name);
+  dump_buff();
+  printf("\n");
 #endif
 
   memset(BUFF, 0, sizeof(Term) * def.nodes_len);
@@ -1040,7 +1037,7 @@ static Term expand_ref(TM *tm, Loc def_idx) {
   for (u32 i = 0; i < rbag_len; i += 2) {
     Term neg = term_offset_loc(rbag[i], offset);
     Term pos = term_offset_loc(rbag[i+1], offset);
-    rbag_push(tm, neg, pos);
+    rbag_push(tm, neg, pos, false);
   }
   return root;
 }
@@ -1057,33 +1054,17 @@ static void boot(Loc def_idx) {
 
 // Atomic Linker
 
-static Term get_loop(Loc loc) {
-  fprintf(stderr, "get_loop\n");
-  // TOOD: tick/timeout
-  while (1) {
-    Term term = get(loc);
-    if (term == 0) {
-      sched_yield();
-    } else {
-      return term;
-    }
-  }
-}
-
 static inline void move(TM *tm, Loc neg_loc, u64 pos);
 static inline void move_lvl(TM *tm, Loc neg_loc, Term pos, u32 lvl);
 
 static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
     Term far = swap_lvl(term_loc(pos), neg, lvl);
-    if (far == 0) {
-      far = get_loop(term_loc(pos + 1));
-    }
     if (term_tag(far) != SUB) {
       move_lvl(tm, term_loc(pos), far, lvl + 1);
     }
   } else {
-    rbag_push(tm, neg, pos);
+    rbag_push(tm, neg, pos, false);
   }
 }
 
@@ -1566,12 +1547,13 @@ static void interact_erasup(TM *tm, Loc b_loc) {
 
 static char *tag_to_str(Tag tag);
 
-static void interact(TM *tm, Term neg, Term pos) {
+static bool interact(TM *tm, Term neg, Term pos) {
   Tag neg_tag = term_tag(neg);
   Tag pos_tag = term_tag(pos);
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
+  bool res = false;
   bool processed = true;
 
   switch (neg_tag) {
@@ -1587,7 +1569,21 @@ static void interact(TM *tm, Term neg, Term pos) {
       interact_appu32(tm, neg_loc, pos_loc);
       break;
     case REF:
-      link_terms(tm, neg, expand_ref(tm, pos_loc));
+#if 1
+      {
+        Term lam = expand_ref(tm, pos_loc);
+        if (term_tag(lam) != LAM) {
+          // Assumption broken. May not matter, but I want to know.
+          fprintf(stderr, "APPREF root node is not a LAM, %s\n",
+                  tag_to_str(term_tag(lam)));
+          mlog_exit();
+        }
+        // force push to overflow buffer
+        rbag_push(tm, neg, lam, true);
+      }
+#else
+      link_terms(tm, neg, expand_ref(tm, pos_loc);
+#endif
       break;
     case SUP:
       interact_appsup(tm, neg_loc, pos_loc);
@@ -1714,6 +1710,8 @@ static void interact(TM *tm, Term neg, Term pos) {
   if (!processed) {
     unprocessed_itrs[neg_tag * 16 + pos_tag] = 1;
   }
+
+  return res;
 }
 
 static void show_unprocessed_itrs() {
@@ -1732,18 +1730,20 @@ static void show_unprocessed_itrs() {
   }
 }
 
-static inline bool sequential_step(TM* tm) {
-  Loc loc = rbag_pop(tm);
-
+static bool sequential_step(TM* tm) {
+  Loc loc = redex_pop_loc(tm);
   if (loc == 0) {
     return false;
   }
-
   Pair pair = take_pair(loc, false);
   interact(tm, pair_neg(pair), pair_pos(pair));
   return true;
 }
-
+ 
+static bool can_idle(TM *tm) {
+  return (tm->oput[0] == 0) && (tm->oput[1] == 0);
+}
+ 
 static bool set_idle(bool was_busy) {
   if (was_busy) {
     atomic_fetch_add_explicit(&net.idle, 1, memory_order_relaxed);
@@ -1773,10 +1773,9 @@ static bool try_steal(TM *tm) {
       tm->spop = tm->bput;
       tm->sid = tm->tid;
 
-#ifdef DEBUG
+      #ifdef DEBUG
       fprintf(stderr, "%u stealing own non-empty booty bag\n", tm->tid);
-#endif
-
+      #endif
       return true;
     } else {
       // To steal from our own full bag, we need to atomic swap
@@ -1785,10 +1784,9 @@ static bool try_steal(TM *tm) {
         tm->spop = tm->bput; // will always be BBAG_LEN
         tm->sid = tm->tid;
 
-#ifdef DEBUG
+        #ifdef DEBUG
         fprintf(stderr, "%u stole own full booty bag\n", tm->tid);
-#endif
-
+        #endif
         return true;
       }
     }
@@ -1813,8 +1811,10 @@ static bool try_steal(TM *tm) {
   return false;
 }
 
-static bool timeout(u32 tick) {
-  if (tick % 256 == 0) {
+#define IDLE 256
+
+static bool timeout(u64 tick) {
+  if (tick % IDLE == 0) {
     u32 idle = atomic_load_explicit(&net.idle, memory_order_relaxed);
     if (idle == TPC) {
       return true;
@@ -1823,7 +1823,7 @@ static bool timeout(u32 tick) {
   return false;
 }
 
-static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
+static bool take_and_interact(TM *tm, Loc loc, bool from_bty) {
   Pair pair = take_pair(loc, from_bty);
 
   if (from_bty && (tm->spop == 0)) {
@@ -1846,29 +1846,102 @@ static void take_and_interact(TM *tm, Loc loc, bool from_bty) {
     tm->sid = TPC;
   }
 
-  interact(tm, pair_neg(pair), pair_pos(pair));
+  return interact(tm, pair_neg(pair), pair_pos(pair));
+}
+
+struct SIMPLE_SYNC {
+  a64 arrived;
+  a64 departed;
+} ss;
+
+static bool sync_start(u32 tid) {
+  u64 prev_arrived = atomic_fetch_add_explicit(&ss.arrived, 1, memory_order_relaxed);
+  if (prev_arrived + 1 == TPC) {
+    // Last to arrive
+    atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
+    atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
+    return true;
+  }
+  return false;
+}
+
+static bool sync_wait(bool departed) {
+  u64 dep_cnt = 0;
+  if (!departed) {
+    dep_cnt = atomic_fetch_add_explicit(&ss.departed, 1, memory_order_release);
+  } else {
+    dep_cnt = atomic_load_explicit(&ss.departed, memory_order_relaxed);
+  }
+  if ((dep_cnt % TPC) == 0) {
+    atomic_thread_fence(memory_order_acquire);
+    return false;
+  } else {
+    return true;
+  }
 }
 
 static void* thread_func(void* arg) {
   thread_id = (u64)arg;
   TM *tm = tms[thread_id];
 
-  // Wait until after injection to turn on booty bag usage
-  // TODO: this could be a global net flag i think.
+  // Wait until after injection to turn these on
   tm->buse = true;
+  tm->ouse = true;
+  //tm->otak = true;
 
-  u32  tick = 0;
+  // Overflow synchronization
+  // TODO: Could moving these to global to reduce code in this funciton
+  bool syncing = false;
+  bool departed = false;
+
+  u64  tick = 0;
   bool busy = tm->tid == 0;
   while (true) {
+    #ifdef MEMLOG
     pthread_testcancel();
+    #endif
 
     tick += 1;
 
+    if (tm->ouse) {
+      if ((tick % OFLW_SYNC) == 0) {
+        if (!syncing) {
+          departed = sync_start(tm->tid);
+          syncing = true;
+
+          if (oflw_debug) {
+            fprintf(stderr, "%u syncing, stop taking from overflow %u oput %u\n",
+                    tm->tid, 0u+tm->opid, tm->oput[tm->opid]);
+          }
+          
+          // TODO: assert(oput[oidx] == 0);
+          tm->opid = 1 - tm->opid;
+          // Just in case it's not empty (it should be)
+          //tm->otak = false;
+          tm->osyn = false;
+        }
+      } else if (syncing) {
+        syncing = sync_wait(departed);
+        departed = true;
+        if (!syncing) {
+
+          if (oflw_debug) {
+            fprintf(stderr, "%u sync'd, can take from overflow %u size %u\n",
+                    tm->tid, 1u-tm->opid, tm->oput[1u-tm->opid]);
+          }
+
+          //tm->otak = true;
+          tm->osyn = true;
+          // Reset tick count to ensure we empty oveflow before next sync point
+          // TODO: could also try something like:
+          //       if ((tick % sync) < oput[1-oidx]) tick = sync - oput[1-oidx]
+          tick = 0;
+        }
+      }
+    }
+
     bool from_bty = tm->spop > 0; // haxor
-    // TODO: I think i can adjust rbag_pop() to not include RBAG, and thus pass
-    // down the "loc < BBAG_LEN" logic to here in order to determine if this
-    // was a booty-bag pop. That'll move some tid vs. sid logic here though.
-    Loc loc = rbag_pop(tm);
+    Loc loc = redex_pop_loc(tm);
     if (loc) {
       busy = set_busy(busy);
 
@@ -1877,24 +1950,22 @@ static void* thread_func(void* arg) {
         tm->bful = false;
         tm->bput = 0;
 
-#ifdef DEBUG
+        #ifdef DEBUG
         fprintf(stderr, "%u recovered stolen, empty booty bag\n", tm->tid);
-#endif
-        //tm->sid = TPC;
+        #endif
       }
 
       take_and_interact(tm, loc, from_bty);
 
       if (!tm->bful && (tm->bput == BBAG_LEN)) {
         // Booty bag was filled by the preceding interaction
-
         // Signal that it can be stolen aka drop()
         bbag_set(tm->tid, FULL, memory_order_release);
         tm->bful = true;
       }
-    } else {
+    } else if (can_idle(tm)) {
       busy = set_idle(busy);
-      if (!try_steal(tm)) {
+      if (!busy && !try_steal(tm)) {
         sched_yield();
         if (timeout(tick))
           break;
@@ -1906,15 +1977,16 @@ static void* thread_func(void* arg) {
   atomic_fetch_add(&net.itrs, tm->itrs);
 
   if (1) {
-    fprintf(stderr, "t%u: %" PRIu64 " itrs, rput: %u, bput: %u, spop: %u, steals: %u good %u bad\n",
-            tm->tid, tm->itrs, tm->rput, tm->bput, tm->spop, tm->sgud, tm->sbad);
+    fprintf(stderr, "t%u itrs %" PRIu64 ", steals good %u bad %u\n",
+            tm->tid, tm->itrs, tm->sgud, tm->sbad);
   }
   return NULL;
 }
 
 static void parallel_normalize() {
-  // Initialize the global idle counter
-  atomic_store_explicit(&net.idle, TPC - 1, memory_order_relaxed);
+  atomic_store_explicit(&net.idle, TPC-1, memory_order_relaxed);
+  atomic_store_explicit(&ss.arrived, ZERO, memory_order_relaxed);
+  atomic_store_explicit(&ss.departed, ZERO, memory_order_relaxed);
 
   for (u64 i = 0; i < TPC; i++) {
     /*int rc = */thread_create(&threads[i], NULL, thread_func, (void*)i);
@@ -1958,7 +2030,7 @@ void handle_failure() {
 // Debugging
 static char *tag_to_str(Tag tag) {
   switch (tag) {
-  case VOID:
+  case 0:
     return "___";
   case VAR:
     return "VAR";

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -160,7 +160,7 @@ enum : u32 {
   NODE_LEN = (HEAP_SIZE - RBAG_SIZE) / (TPC * sizeof(u64)),
 
   // Booty-bag length in u64 elements
-  BBAG_LEN = 96
+  BBAG_LEN = 8
 };
 
 typedef struct Net {
@@ -255,7 +255,7 @@ static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
 Loc term_loc(Term term);
 
-//#define MEMLOG // comment out to disable
+#define MEMLOG // comment out to disable
 
 #ifdef MEMLOG
 // Memory operations log
@@ -962,7 +962,7 @@ static void boot(Loc def_idx) {
 // Atomic Linker
 
 static Term get_loop(Loc loc) {
-  //fprintf(stderr, "get_loop\n");
+  fprintf(stderr, "get_loop\n");
   // TOOD: tick/timeout
   while (1) {
     Term term = get(loc);
@@ -981,7 +981,7 @@ static inline void link_lvl(TM *tm, Term neg, Term pos, u32 lvl) {
   if (term_tag(pos) == VAR) {
     Term far = swap_lvl(term_loc(pos), neg, lvl);
     if (far == 0) {
-      //far = get_loop(term_loc(pos + 1));
+      far = get_loop(term_loc(pos + 1));
     }
     if (term_tag(far) != SUB) {
       move_lvl(tm, term_loc(pos), far, lvl + 1);
@@ -1016,7 +1016,7 @@ static bool interact_applam(TM *tm, Loc a_loc, Loc b_loc) {
 
   // Magic to make race condition appear more frequently
   bool buse = tm->buse;
-  //  tm->buse = false;
+  tm->buse = false;
 
   move(tm, var, arg);
   move(tm, ret, bod);

--- a/src/Runtime.c
+++ b/src/Runtime.c
@@ -213,6 +213,7 @@ typedef struct BB {
 static TM *tms[TPC];
 static BB *bbs[TPC];
 static thread_t threads[TPC];
+static uint8_t unprocessed_itrs[255] = { 0 };
 
 static _Thread_local int thread_id = 0;
 
@@ -227,7 +228,7 @@ void dump_buff(TM *tm);
 static const char* term_str(char* buf, Term term);
 Tag term_tag(Term term) { return term & 0xFF; }
 
-//#define MEMLOG // comment out to disable
+#define MEMLOG // comment out to disable
 
 #ifdef MEMLOG
 
@@ -1371,6 +1372,8 @@ static void interact(TM *tm, Term neg, Term pos) {
   Loc neg_loc = term_loc(neg);
   Loc pos_loc = term_loc(pos);
 
+  bool processed = true;
+
   switch (neg_tag) {
   case APP:
     switch (pos_tag) {
@@ -1389,12 +1392,13 @@ static void interact(TM *tm, Term neg, Term pos) {
     case SUP:
       interact_appsup(tm, neg_loc, pos_loc);
       break;
+    default:
+      processed = false;
+      break;
     }
     break;
   case OPX:
     switch (pos_tag) {
-    case LAM:
-      break;
     case NUL:
       interact_opxnul(tm, neg_loc);
       break;
@@ -1409,12 +1413,14 @@ static void interact(TM *tm, Term neg, Term pos) {
     case SUP:
       interact_opxsup(tm, neg_loc, term_lab(neg), pos_loc);
       break;
+    case LAM:
+    default:
+      processed = false;
+      break;
     }
     break;
   case OPY:
     switch (pos_tag) {
-    case LAM:
-      break;
     case NUL:
       interact_opynul(tm, neg_loc);
       break;
@@ -1428,6 +1434,10 @@ static void interact(TM *tm, Term neg, Term pos) {
       break;
     case SUP:
       interact_opysup(tm, neg_loc, pos_loc);
+      break;
+    case LAM:
+    default:
+      processed = false;
       break;
     }
     break;
@@ -1452,12 +1462,13 @@ static void interact(TM *tm, Term neg, Term pos) {
     case SUP:
       interact_dupsup(tm, neg_loc, pos_loc);
       break;
+    default:
+      processed = false;
+      break;
     }
     break;
   case MAT:
     switch (pos_tag) {
-    case LAM:
-      break;
     case NUL:
       interact_matnul(tm, neg_loc, term_lab(neg));
       break;
@@ -1472,6 +1483,10 @@ static void interact(TM *tm, Term neg, Term pos) {
     case SUP:
       interact_matsup(tm, neg_loc, term_lab(neg), pos_loc);
       break;
+    case LAM:
+    default:
+      processed = false;
+      break;
     }
     break;
   case ERA:
@@ -1479,20 +1494,42 @@ static void interact(TM *tm, Term neg, Term pos) {
     case LAM:
       interact_eralam(tm, pos_loc);
       break;
-    case NUL:
-      break;
-    case U32:
-      break;
-    case REF:
-      break;
     case SUP:
       interact_erasup(tm, pos_loc);
       break;
+    case NUL:
+    case U32:
+    case REF:
+    default:
+      processed = false;
+      break;
     }
     break;
+  default:
+    processed = false;
+    break;
   }
-
   tm->itrs += 1;
+
+  if (!processed) {
+    unprocessed_itrs[neg_tag * 16 + pos_tag] = 1;
+  }
+}
+
+static void show_unprocessed_itrs() {
+  for (u32 i = 17; i <= 255; i++) {
+    u32 pos_tag = i % 16;
+    if (pos_tag < 1) continue;
+    u32 neg_tag = i / 16;
+    bool hdr = true;
+    if (unprocessed_itrs[neg_tag*16 + pos_tag]) {
+      if (hdr) {
+        fprintf(stderr, "Unprocesed itrs:\n");
+        hdr = false;
+      }
+      fprintf(stderr, "%s%s\n", tag_to_str(neg_tag), tag_to_str(pos_tag));
+    }
+  }
 }
 
 static inline bool sequential_step(TM* tm) {
@@ -1505,23 +1542,6 @@ static inline bool sequential_step(TM* tm) {
   Pair pair = take_pair(loc);
   interact(tm, pair_neg(pair), pair_pos(pair));
   return true;
-}
-
-// A simple spin-wait barrier using atomic operations
-a64 a_reached = 0; // number of threads that reached the current barrier
-a64 a_barrier = 0; // number of barriers passed during this program
-static void sync_threads() {
-  u64 barrier_old = atomic_load_explicit(&a_barrier, memory_order_relaxed);
-  if (atomic_fetch_add_explicit(&a_reached, 1, memory_order_relaxed) == (TPC - 1)) {
-    // Last thread to reach the barrier resets the counter and advances the barrier
-    atomic_store_explicit(&a_reached, 0, memory_order_relaxed);
-    atomic_store_explicit(&a_barrier, barrier_old + 1, memory_order_release);
-  } else {
-    u32 tries = 0;
-    while (atomic_load_explicit(&a_barrier, memory_order_acquire) == barrier_old) {
-      sched_yield();
-    }
-  }
 }
 
 static bool set_idle(bool was_busy) {
@@ -1649,6 +1669,8 @@ static void parallel_normalize() {
   for (u64 i = 0; i < TPC; i++) {
     thread_join(threads[i], NULL);
   }
+
+  show_unprocessed_itrs();
 }
 
 Term normalize(Term term) {

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -118,8 +118,8 @@ foreign import ccall unsafe "Runtime.c def_name"
 defName :: Loc -> IO String
 defName loc = defName_ loc >>= peekCString
 
-foreign import ccall unsafe "Runtime.c swap"
-  swap :: Loc -> Term -> IO Term
+-- foreign import ccall unsafe "Runtime.c swap"
+--  swap :: Loc -> Term -> IO Term
 
 foreign import ccall unsafe "Runtime.c get"
   get :: Loc -> IO Term
@@ -127,7 +127,7 @@ foreign import ccall unsafe "Runtime.c get"
 foreign import ccall unsafe "Runtime.c set"
   set :: Loc -> Term -> IO ()
 
-foreign import ccall unsafe "Runtime.c rbag_push"
+foreign import ccall unsafe "Runtime.c ffi_rbag_push"
   rbagPush :: Term -> Term -> IO ()
 
 foreign import ccall unsafe "Runtime.c rbag_ini"
@@ -142,7 +142,7 @@ foreign import ccall unsafe "Runtime.c rnod_end"
 -- foreign import ccall unsafe "Runtime.c take"
 --   take :: Loc -> IO Term
 
-foreign import ccall unsafe "Runtime.c alloc_node"
+foreign import ccall unsafe "Runtime.c ffi_alloc_node"
   allocNode :: Word64 -> IO Loc
 
 foreign import ccall unsafe "Runtime.c inc_itr"

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -154,6 +154,9 @@ foreign import ccall unsafe "Runtime.c normalize"
 foreign import ccall unsafe "Runtime.c dump_buff"
   dumpBuff :: IO ()
 
+foreign import ccall unsafe "Runtime.c handle_failure"
+  callFailureHandler :: IO ()
+
 -- Convenience Functions
 
 termOper :: Term -> Oper

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -130,13 +130,13 @@ foreign import ccall unsafe "Runtime.c set"
 foreign import ccall unsafe "Runtime.c ffi_rbag_push"
   rbagPush :: Term -> Term -> IO ()
 
-foreign import ccall unsafe "Runtime.c rbag_ini"
+foreign import ccall unsafe "Runtime.c ffi_rbag_ini"
   rbagIni :: IO Loc
 
-foreign import ccall unsafe "Runtime.c rbag_end"
+foreign import ccall unsafe "Runtime.c ffi_rbag_end"
   rbagEnd :: IO Loc
 
-foreign import ccall unsafe "Runtime.c rnod_end"
+foreign import ccall unsafe "Runtime.c ffi_rnod_end"
   rnodEnd :: IO Loc
 
 -- foreign import ccall unsafe "Runtime.c take"


### PR DESCRIPTION

    ./bench.sh 100
    Running cabal run . -- run examples/bench_parallel_sum_range.hvms -s for 100 iterations...
    --------
    Min MIPS: 703
    Max MIPS: 786
    Avg MIPS: 738.49
    
    Main changes:
    
    * Memory layout - Adopted HVM2's memory layout for RBAG and RNOD, by first
      dividing all available heap space into separate RNOD an RBAG spaces, then
      sub-dividing each of those into thread-"owned" chunks of the same size.
      * Reads and writes to thread-owned RBAG space are non-atomic.
      * Writes to thread-owned RNOD space via expand_ref() are non-atomic; all
        other reads and writes to RNOD space are atomic.
    
    * Work stealing - A small buffer at the beginning of each thread-owned RBAG
      space is called the "booty bag" or BBAG. This is filled with newly pushed
      redexes before any redexes are pushed to the "normal" RBAG.
      * Threads (including the owning thread, if necessary) can steal the entire
        bag, and when that happens, it is prioritized as a redex pop-source until
        it becomes empty.
    
    * Deferred redexes - Two small buffers at the end of each thread-owned RBAG
      space are known as deferred bags, or DFER. They contains only APPLAM redexes
      that result from combining the APP and the root node LAM of an APPREF redex
      that has been "expanded" in expand_ref().
      * There are two bags because they alternate being pushed-into and popped-from
      * When these bags reach a certain threshold in size, memory written to them
        is synchronized (on ARM), and they are prioritized as a redex pop-source.
      * This was done as an optimization to the race condition fix. It resulted
        in better performance than synchronizing memory after every APPREF.
    
    * Race condition fix - pushing the APPLAM redex resulting from an APPREF inter-
      action "publishes" an address internal to that LAM node's "address space" via
      the Loc field of the LAM term. There was no guarantee that the the memory
      written to that space would be available to other threads to read, or that
      once one location in that space became available, all other locations would
      also be vailabe.
      * This was solved (hopefully) with a `dmb ishst` Inner Shared Domain Store
        Barrier inline assembly instruction on ARM to synchronize all prior writes,
        before pushing one of those APPLAM redexes.
    
    Other changes:
    
    * Bind threads to specific cores on ARM. Threads 0-3 to Pcores, 4-N to Ecores.
      * Number of Pcores is defined by enum value PCOR_TOT, and currently must be
        manually changed for architectures with more than 4 Pcores.
    
    * Improved work-stealing victim identfication on ARM. It uses a Pcore-biased
      round-robin approach.
    
    Notes:
    
    * Technically, it is undefined behavior to access a memory location using both
      atomic and non-atomic loads and/or stores. However, a) it works, and b) it is
      my understanding that there is significant legacy code that depends on it
      continuing to work, so it's my belief that it is "safe" to do.
    
    * Only the following 7 interaction types have actually been tested, because
      these are the only interactions used by the parallel sum benchmark:
    
      APPLAM, APPREF, DUPNUM, MATNUM, MATREF, OPXNUM, OPYNUM     
