### PR TITLE
Working, fast, parallel version of HVM3-Strict. ~735MIPS w/10 threads.

### DIFF
--- a/HVM3-Strict.cabal
+++ b/HVM3-Strict.cabal
@@ -11,24 +11,25 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
 common warnings
-    ghc-options: -Wall
+    ghc-options:          -Wall
 
 executable hvms
-    import:           warnings
-    main-is:          Main.hs
-    other-modules:    Type
-                    , Extract
-                    , Inject
-                    , Parse
-                    , Show
-    build-depends:    base ^>=4.21.0.0,
-                      containers ^>=0.7,
-                      parsec ^>=3.1.17.0,
-                      clock
-    hs-source-dirs:   src
-    default-language: GHC2024
-    c-sources:        src/Runtime.c
-    -- cc-options: -march=native -ftree-vectorize
-    cc-options:  -O3
-    extra-libraries:  c
-    ghc-options:     -Wno-all
+    import:               warnings
+    main-is:              Main.hs
+    other-modules:        Type
+                        , Extract
+                        , Inject
+                        , Parse
+                        , Show
+    build-depends:        base ^>=4.21.0.0,
+                          containers ^>=0.7,
+                          parsec ^>=3.1.17.0,
+                          clock
+    hs-source-dirs:       src
+    default-language:     GHC2024
+    c-sources:            src/Runtime.c
+    cc-options:           -O3 -Wall -Werror -std=c11
+    extra-libraries:      c
+    if os(linux)
+        extra-libraries:  atomic
+    ghc-options:          -Wno-all

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+num_itrs=20
+
+if [[ $# > 0 ]]; then
+  num_itrs="$1"
+fi
+
+cleanup() {
+    echo "Caught CTRL+C, cleaning up..."
+    pkill -P $$
+    exit 1
+}
+
+trap cleanup SIGINT
+
+cmd="cabal run . -- run examples/bench_parallel_sum_range.hvms -s"
+
+tot_mips=0
+min_mips=999999999
+max_mips=0
+fst_itrs=0
+outfile=out.bench
+
+echo "Running $cmd for $num_itrs iterations..."
+
+for (( i=1; i<=$num_itrs; i++ )); do
+    output=$($cmd 2>$outfile)
+    
+    mips=$(echo "$output" | grep "MIPS:" | awk '{print $2}')
+    itrs=$(echo "$output" | grep "ITRS:" | awk '{print $2}')
+    size=$(echo "$output" | grep "SIZE:" | awk '{print $2}')
+    
+    [[ -z "$itrs" ]] && err=1 || err=0
+
+    if (( !err )) && [[ $fst_itrs == 0 ]]; then
+        fst_itrs="$itrs"
+    elif (( err )) || [[ $fst_itrs != $itrs ]]; then
+        if (( err )); then
+            echo "ERROR @ $i: missing ITRS"
+        else
+            echo "ERROR @ $i: ITRS: $itrs mismatch with first ITRS: $fst_itrs"
+        fi
+        echo "Output:"
+        echo "$output"
+        echo "------"
+        echo "tail $outfile:"
+        tail "$outfile"
+        exit 1
+    fi
+
+    if [[ $mips < $min_mips ]]; then
+        min_mips="$mips"
+    fi
+    
+    if [[ $mips > $max_mips ]]; then
+        max_mips="$mips"
+    fi
+    
+    tot_mips=$((tot_mips + mips))
+done
+
+avg_mips=$(echo "scale=2; $tot_mips / $num_itrs" | bc -l)
+
+echo "--------"
+echo "Min MIPS: $min_mips"
+echo "Max MIPS: $max_mips"
+echo "Avg MIPS: $avg_mips"

--- a/examples/bench_parallel_sum_range.hvms
+++ b/examples/bench_parallel_sum_range.hvms
@@ -1,4 +1,4 @@
-@height = 19
+@height = 20
 
 @leaf = (a (* ((a b) b)))
 @node = (a (b ((a (b c)) (* c))))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -50,19 +50,20 @@ cliRun filePath showStats = do
   end <- getTime Monotonic
     
   net <- extractNet term
-
-  putStrLn $ netToString net
+  let str = netToString net
+  putStrLn $ str
+  when (not (null str) && head str == 'v') $ do
+    callFailureHandler
 
   when showStats $ do
-    -- end <- getCPUTime
     let timeInMs = fromIntegral (toNanoSecs (diffTimeSpec end start)) / 1000000 :: Double
     itr <- incItr
     len <- rnodEnd
     let mips = (fromIntegral itr / 1000000.0) / (((timeInMs))/ 1000.0)
     putStrLn $ "ITRS: " ++ show itr
-    putStrLn $ "INTERACTION TIME: " ++ show timeInMs ++ "ms"
+    putStrLn $ "TIME: " ++ show (truncate timeInMs) ++ "ms"
     putStrLn $ "SIZE: " ++ show len
-    putStrLn $ "MIPS: " ++ show mips
+    putStrLn $ "MIPS: " ++ show (truncate mips)
 
   hvmFree
 

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -118,8 +118,8 @@ foreign import ccall unsafe "Runtime.c def_name"
 defName :: Loc -> IO String
 defName loc = defName_ loc >>= peekCString
 
-foreign import ccall unsafe "Runtime.c swap"
-  swap :: Loc -> Term -> IO Term
+-- foreign import ccall unsafe "Runtime.c swap"
+--  swap :: Loc -> Term -> IO Term
 
 foreign import ccall unsafe "Runtime.c get"
   get :: Loc -> IO Term
@@ -127,22 +127,22 @@ foreign import ccall unsafe "Runtime.c get"
 foreign import ccall unsafe "Runtime.c set"
   set :: Loc -> Term -> IO ()
 
-foreign import ccall unsafe "Runtime.c rbag_push"
+foreign import ccall unsafe "Runtime.c ffi_rbag_push"
   rbagPush :: Term -> Term -> IO ()
 
-foreign import ccall unsafe "Runtime.c rbag_ini"
+foreign import ccall unsafe "Runtime.c ffi_rbag_ini"
   rbagIni :: IO Loc
 
-foreign import ccall unsafe "Runtime.c rbag_end"
+foreign import ccall unsafe "Runtime.c ffi_rbag_end"
   rbagEnd :: IO Loc
 
-foreign import ccall unsafe "Runtime.c rnod_end"
+foreign import ccall unsafe "Runtime.c ffi_rnod_end"
   rnodEnd :: IO Loc
 
 -- foreign import ccall unsafe "Runtime.c take"
 --   take :: Loc -> IO Term
 
-foreign import ccall unsafe "Runtime.c alloc_node"
+foreign import ccall unsafe "Runtime.c ffi_alloc_node"
   allocNode :: Word64 -> IO Loc
 
 foreign import ccall unsafe "Runtime.c inc_itr"
@@ -153,6 +153,9 @@ foreign import ccall unsafe "Runtime.c normalize"
 
 foreign import ccall unsafe "Runtime.c dump_buff"
   dumpBuff :: IO ()
+
+foreign import ccall unsafe "Runtime.c handle_failure"
+  callFailureHandler :: IO ()
 
 -- Convenience Functions
 


### PR DESCRIPTION
./bench.sh 100
Running cabal run . -- run examples/bench_parallel_sum_range.hvms -s for 100 iterations... --------
Min MIPS: 703
Max MIPS: 786
Avg MIPS: 738.49

Main changes:

* Memory layout - Adopted HVM2's memory layout for RBAG and RNOD, by first dividing all available heap space into separate RNOD an RBAG spaces, then sub-dividing each of those into thread-"owned" chunks of the same size.
  * Reads and writes to thread-owned RBAG space are non-atomic.
  * Writes to thread-owned RNOD space via expand_ref() are non-atomic; all other reads and writes to RNOD space are atomic.

* Work stealing - A small buffer at the beginning of each thread-owned RBAG space is called the "booty bag" or BBAG. This is filled with newly pushed redexes before any redexes are pushed to the "normal" RBAG.
  * Threads (including the owning thread, if necessary) can steal the entire bag, and when that happens, it is prioritized as a redex pop source until it becomes empty.

* Deferred redexes - Two small buffers at the end of each thread-owned RBAG space are known as deferred bags, or DFER. They contains only APPLAM redexes that result from combining the APP and the root LAM term of an expanded APPREF redex.
  * There are two bags because they alternate being pushed-into and popped-from.
  * When one of these bags reaches a certain threshold in size, memory written to them is synchronized (on ARM), and they are prioritized as a redex pop source.
  * This was done as an optimization to the race condition fix. It resulted in better performance than synchronizing memory after every APPREF.

* Race condition fix - pushing the APPLAM redex that results from an APPREF interaction "publishes" an address internal to that LAM node's "address space" via the Loc field of the LAM term. There was no guarantee that the prior writes to locations within that space would be visible to other threads to read, or that once once one location in that space became visible, all other locations in that space would also be visible.
  * This was solved (hopefully) with a `dmb ishst` Inner SHareable domain STore barrier inline assembly instruction on ARM to synchronize all prior writes, before pushing one of those APPLAM redexes.

Other changes:

* Bind threads to specific cores on ARM. Threads 0-3 to Pcores, 4-N to Ecores.
  * Number of Pcores is defined by enum value PCOR_TOT, and currently must be manually changed for architectures with more than 4 Pcores.

* Improved work-stealing victim identfication on ARM. It uses a Pcore-biased round-robin approach.

* Added a rudimentary bench.sh script to root of tree to make benchmarking multiple easier.

Notes:

* Technically, it is undefined behavior to access a memory location using both atomic and non-atomic loads and/or stores. However, a) it works, and b) it is my understanding that there is significant legacy code that depends on it continuing to work, so it's my belief that it is "safe" to do.

* Only the following 7 interaction types have actually been tested, because these are the only interactions used by the parallel sum benchmark:

  APPLAM, APPREF, DUPNUM, MATNUM, MATREF, OPXNUM, OPYNUM